### PR TITLE
Service klassen opgesteld om een beeld te geven waar verantwoordelijkheden liggen

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/application/BatteryService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/BatteryService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BatteryService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/GameService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/GameService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GameService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/HouseService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/HouseService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HouseService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LevelService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/TransformerService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/TransformerService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransformerService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/WindmillService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/WindmillService.java
@@ -1,0 +1,7 @@
+package nl.hu.serious_game.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class WindmillService {
+}

--- a/back-end/src/main/java/nl/hu/serious_game/application/testService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/testService.java
@@ -1,3 +1,0 @@
-package nl.hu.serious_game.application;
-
-public class testService {}


### PR DESCRIPTION
Service lagen zijn aangemaakt om een beeld te geven wat de aanspreekpunten zijn voor het domein. Elk stukje domein waar verantwoordelijkheden best nauw gekoppeld zijn hebben dan 1 "hoofd" service ipv een service per elk stukje domein.