### PR TITLE
T 70 dag profiel domein & T 81 dag profiel tests

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class DayProfile {
     private Season season;
-    private Map<Integer, Map<String, Double>> hourData;
+    private Map<Integer, Map<String, Float>> hourData;
 
     public DayProfile(Season season) {
         this.season = season;
@@ -16,28 +16,28 @@ public class DayProfile {
     }
 
     private void initializeData() {
-        double[] solarPanelProduction = {
-                0, 0, 0, 0, 0, 0, 0, 0, 0.017857143, 0.107142857, 0.160714286, 0.178571429,
-                0.196428571, 0.196428571, 0.196428571, 0.178571429, 0.160714286, 0.107142857,
-                0.017857143, 0, 0, 0, 0, 0
+        float[] solarPanelProduction = {
+                0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0.017857143f, 0.107142857f, 0.160714286f, 0.178571429f,
+                0.196428571f, 0.196428571f, 0.196428571f, 0.178571429f, 0.160714286f, 0.107142857f,
+                0.017857143f, 0f, 0f, 0f, 0f, 0f
         };
 
-        double[] houseBaseConsumption = {
-                0.277, 0.277, 0.277, 0.277, 0.277, 0.277, 0.277, 0.277, 0.39, 0.39, 0.39, 0.39,
-                0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.39, 0.277
+        float[] houseBaseConsumption = {
+                0.277f, 0.277f, 0.277f, 0.277f, 0.277f, 0.277f, 0.277f, 0.277f, 0.39f, 0.39f, 0.39f, 0.39f,
+                0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.277f
         };
 
         for (int hour = 0; hour < 24; hour++) {
-            Map<String, Double> data = new HashMap<>();
+            Map<String, Float> data = new HashMap<>();
             data.put("SolarPanelProduction", solarPanelProduction[hour]);
             data.put("HouseBaseConsumption", houseBaseConsumption[hour]);
             hourData.put(hour, data);
         }
     }
 
-    public double getValue(int hour, String column) {
+    public float getValue(int hour, String column) {
         if (hourData.containsKey(hour) && hourData.get(hour).containsKey(column)) {
-            double value = hourData.get(hour).get(column);
+            float value = hourData.get(hour).get(column);
 
             // Apply relevant season factors for each column
             if (column.equals("SolarPanelProduction")) {
@@ -48,7 +48,7 @@ public class DayProfile {
 
             // Round to 4 decimals
             BigDecimal roundedValue = new BigDecimal(value).setScale(4, RoundingMode.HALF_UP);
-            return roundedValue.doubleValue();
+            return roundedValue.floatValue();
         }
         throw new IllegalArgumentException("Invalid hour or column");
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Season.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Season.java
@@ -1,24 +1,24 @@
 package nl.hu.serious_game.domain;
 
 public enum Season {
-    SPRING(0.89, 1.25),
-    SUMMER(1, 1),
-    AUTUMN(0.54, 1.25),
-    WINTER(0.27, 1.5);
+    SPRING(0.89f, 1.25f),
+    SUMMER(1f, 1f),
+    AUTUMN(0.54f, 1.25f),
+    WINTER(0.27f, 1.5f);
 
-    private final double solarPanelFactor;
-    private final double houseBaseConsumptionFactor;
+    private final float solarPanelFactor;
+    private final float houseBaseConsumptionFactor;
 
-    Season(double solarPanelFactor, double houseBaseConsumptionFactor) {
+    Season(float solarPanelFactor, float houseBaseConsumptionFactor) {
         this.solarPanelFactor = solarPanelFactor;
         this.houseBaseConsumptionFactor = houseBaseConsumptionFactor;
     }
 
-    public double getSolarPanelFactor() {
+    public float getSolarPanelFactor() {
         return solarPanelFactor;
     }
 
-    public double getHouseBaseConsumptionFactor() {
+    public float getHouseBaseConsumptionFactor() {
         return houseBaseConsumptionFactor;
     }
 }

--- a/back-end/src/test/java/nl/hu/serious_game/domain/DayProfileTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/DayProfileTest.java
@@ -20,7 +20,7 @@ public class DayProfileTest {
     @DisplayName("Summer Test with one solar panel 08:00")
     public void SummerTestOneSolarPanelHour8() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        assertEquals(0.0179, dayProfile.getValue(8, "SolarPanelProduction"));
+        assertEquals(0.0179f, dayProfile.getValue(8, "SolarPanelProduction"));
     }
 
     // Test for checking value of 07:00 for a single solar panel during summer
@@ -31,7 +31,7 @@ public class DayProfileTest {
     @DisplayName("Summer Test with one solar panel 07:00")
     public void SummerTestOneSolarPanelHour7() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        assertEquals(0, dayProfile.getValue(7, "SolarPanelProduction"));
+        assertEquals(0f, dayProfile.getValue(7, "SolarPanelProduction"));
     }
 
     // Test for checking value of 13:00 for a single solar panel during summer
@@ -42,7 +42,7 @@ public class DayProfileTest {
     @DisplayName("Summer Test with one solar panel 13:00")
     public void SummerTestOneSolarPanelHour13() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        assertEquals(0.1964, dayProfile.getValue(13, "SolarPanelProduction"));
+        assertEquals(0.1964f, dayProfile.getValue(13, "SolarPanelProduction"));
     }
 
     // Test for checking value of 13:00 for a single solar panel during winter
@@ -53,7 +53,7 @@ public class DayProfileTest {
     @DisplayName("Winter Test with one solar panel 13:00")
     public void WinterTestOneSolarPanelHour13() {
         DayProfile dayProfile = new DayProfile(Season.WINTER);
-        assertEquals(0.0530, dayProfile.getValue(13, "SolarPanelProduction"));
+        assertEquals(0.0530f, dayProfile.getValue(13, "SolarPanelProduction"));
     }
 
     // Test for checking value of 13:00 for a single solar panel during spring
@@ -64,7 +64,7 @@ public class DayProfileTest {
     @DisplayName("Spring Test with one solar panel 13:00")
     public void SpringTestOneSolarPanelHour13() {
         DayProfile dayProfile = new DayProfile(Season.SPRING);
-        assertEquals(0.1748, dayProfile.getValue(13, "SolarPanelProduction"));
+        assertEquals(0.1748f, dayProfile.getValue(13, "SolarPanelProduction"));
     }
 
     // Test for checking value of 13:00 for a single solar panel during autumn
@@ -75,7 +75,7 @@ public class DayProfileTest {
     @DisplayName("Autumn Test with one solar panel 13:00")
     public void AutumnTestOneSolarPanelHour13() {
         DayProfile dayProfile = new DayProfile(Season.AUTUMN);
-        assertEquals(0.1061, dayProfile.getValue(13, "SolarPanelProduction"));
+        assertEquals(0.1061f, dayProfile.getValue(13, "SolarPanelProduction"));
     }
 
     // Invalid hour throws exception
@@ -102,7 +102,7 @@ public class DayProfileTest {
     @DisplayName("Summer Test with house base consumption 08:00")
     public void SummerTestHouseBaseConsumptionHour8() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        assertEquals(0.39, dayProfile.getValue(8, "HouseBaseConsumption"));
+        assertEquals(0.39f, dayProfile.getValue(8, "HouseBaseConsumption"));
     }
 
     // Test for checking value of 23:00 for a house base consumption during summer
@@ -113,7 +113,7 @@ public class DayProfileTest {
     @DisplayName("Summer Test with house base consumption 23:00")
     public void SummerTestHouseBaseConsumptionHour23() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        assertEquals(0.277, dayProfile.getValue(23, "HouseBaseConsumption"));
+        assertEquals(0.277f, dayProfile.getValue(23, "HouseBaseConsumption"));
     }
 
     // Test for checking value of 23:00 for a house base consumption during winter
@@ -124,6 +124,6 @@ public class DayProfileTest {
     @DisplayName("Winter Test with house base consumption 23:00")
     public void WinterTestHouseBaseConsumptionHour23() {
         DayProfile dayProfile = new DayProfile(Season.WINTER);
-        assertEquals(0.4155, dayProfile.getValue(23, "HouseBaseConsumption"));
+        assertEquals(0.4155f, dayProfile.getValue(23, "HouseBaseConsumption"));
     }
 }


### PR DESCRIPTION
Toch maar T 70 en T 81 in de zelfde branch verwerkt, omdat ik tests maak om vervolgens het domein daarop te maken. Is dus _eigenlijk_ niet volgens de afspraak, maar besproken met Kai.

### Unit tests
- Tests aangemaakt om een aantal randvoorwaardes te controleren, seizoen factoren te testen voor zonnepanelen en exceptions bij invalide waardes
- Tests toegevoegd voor Huis basis consumptie waardes

### Domein
- DayProfile klasse aangepast waarbij alle data van het onderzoek in een 2dimensionale map gestopt wordt en met een get-methode opgehaald kan worden. Waardes worden afgerond op 4 decimalen en de seizoensfactor wordt toegepast (staat in constructor, dus seizoen is altijd verplicht om te bestaan.
- Seizoen Enum: Factor waardes toegevoegd aan seizoenen met specifieke getter methodes om deze op te halen waar nodig