### PR TITLE
T 134 level uitbreiding opties

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/Runner.java
+++ b/back-end/src/main/java/nl/hu/serious_game/Runner.java
@@ -25,8 +25,8 @@ public class Runner implements CommandLineRunner {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
 
         // Create a house
-        House house = new House(1, 4, dayProfile);
-        House house2 = new House(2, 8, dayProfile);
+        House house = new House(1, 4, dayProfile, new HouseOptions());
+        House house2 = new House(2, 8, dayProfile, new HouseOptions());
 
         // Create a single transformer
         Transformer transformer = new Transformer(List.of(house, house2), 10, 1, false);

--- a/back-end/src/main/java/nl/hu/serious_game/Runner.java
+++ b/back-end/src/main/java/nl/hu/serious_game/Runner.java
@@ -9,11 +9,13 @@ import java.util.List;
 @Component
 public class Runner implements CommandLineRunner {
     private Level level1;
+    private Level level2;
 
     @Override
     public void run(String... args) throws Exception {
         System.out.println("Runner started!");
         this.createLevel1();
+        this.createLevel2();
     }
 
     private void createLevel1() {
@@ -37,7 +39,33 @@ public class Runner implements CommandLineRunner {
         System.out.println(level1);
     }
 
+    private void createLevel2() {
+        System.out.println("Creating level 2...");
+        // Create objective
+        Objective objective = new Objective(3, 5);
+
+        // Create a DayProfile
+        DayProfile dayProfile = new DayProfile(Season.SUMMER);
+
+        // Create a house
+        House house = new House(1, 4, dayProfile, new HouseOptions(true, false));
+        House house2 = new House(2, 8, dayProfile, new HouseOptions(false, true));
+        House house3 = new House(2, 8, dayProfile, new HouseOptions(true, true));
+
+        // Create a single transformer
+        Transformer transformer = new Transformer(List.of(house, house2, house3), 10, 1, false);
+
+        this.level2 = new Level(Season.SUMMER, 12, 15, objective, List.of(transformer));
+
+        System.out.println("Level 2 created!");
+        System.out.println(level2);
+    }
+
     public Level getLevel1() {
         return level1;
+    }
+
+    public Level getLevel2() {
+        return level2;
     }
 }

--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
@@ -20,6 +20,8 @@ public class LevelService {
         switch (levelNumber) {
             case 1:
                 return runner.getLevel1();
+            case 2:
+                return runner.getLevel2();
             default:
                 throw new IllegalArgumentException("Invalid level number");
         }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
@@ -26,8 +26,9 @@ public class DayProfile {
         };
 
         float[] heatPumpConsumption = {
-                4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f,
-                4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f
+                0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f,
+                0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f, 0.1825f,
+                0.1825f, 0.1825f, 0.1825f, 0.1825f
         };
 
         float[] electricVehicleConsumption = {
@@ -40,7 +41,7 @@ public class DayProfile {
             data.put("SolarPanelProduction", solarPanelProduction[hour]);
             data.put("HouseBaseConsumption", houseBaseConsumption[hour]);
             data.put("HeatPumpConsumption", heatPumpConsumption[hour]);
-            data.put("ElectricVehicleConsumptionHour", electricVehicleConsumption[hour]);
+            data.put("ElectricVehicleConsumption", electricVehicleConsumption[hour]);
             hourData.put(hour, data);
         }
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/DayProfile.java
@@ -25,10 +25,22 @@ public class DayProfile {
                 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.39f, 0.277f
         };
 
+        float[] heatPumpConsumption = {
+                4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f,
+                4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f, 4.38f
+        };
+
+        float[] electricVehicleConsumption = {
+                0.36f, 0.36f, 0.36f, 0.36f, 0.36f, 0.36f, 0.36f, 0.36f, 0f, 0f, 0f, 0f,
+                0f, 0f, 0f, 0f, 0f, 0f, 0f, 0.36f, 0.36f, 0.36f, 0.36f, 0.36f
+        };
+
         for (int hour = 0; hour < 24; hour++) {
             Map<String, Float> data = new HashMap<>();
             data.put("SolarPanelProduction", solarPanelProduction[hour]);
             data.put("HouseBaseConsumption", houseBaseConsumption[hour]);
+            data.put("HeatPumpConsumption", heatPumpConsumption[hour]);
+            data.put("ElectricVehicleConsumptionHour", electricVehicleConsumption[hour]);
             hourData.put(hour, data);
         }
     }
@@ -41,10 +53,13 @@ public class DayProfile {
             float value = hourData.get(hour).get(column);
 
             // Apply relevant season factors for each column
-            if (column.equals("SolarPanelProduction")) {
-                value *= season.getSolarPanelFactor();
-            } else if (column.equals("HouseBaseConsumption")) {
-                value *= season.getHouseBaseConsumptionFactor();
+            switch (column) {
+                case "SolarPanelProduction" -> value *= season.getSolarPanelFactor();
+                case "HouseBaseConsumption" -> value *= season.getHouseBaseConsumptionFactor();
+                case "HeatPumpConsumption" -> value *= season.getHeatPumpConsumptionFactor();
+                case "ElectricVehicleConsumption" -> {
+                    return value;
+                }
             }
 
             return value;

--- a/back-end/src/main/java/nl/hu/serious_game/domain/House.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/House.java
@@ -64,7 +64,7 @@ public class House implements Cloneable {
         }
     }
 
-    private float getTotalConsumptionOfHour(int hour) {
+    public float getTotalConsumptionOfHour(int hour) {
         float total = getBaseConsumption(hour);
         total += houseOptions.hasHeatpump() ? getHeatPumpConsumption(hour) : 0;
         total += houseOptions.hasElectricVehicle() ? getElectricVehicleConsumption(hour) : 0;

--- a/back-end/src/main/java/nl/hu/serious_game/domain/House.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/House.java
@@ -42,18 +42,33 @@ public class House implements Cloneable {
         return totalSolarPanels * dayProfile.getValue(hour, "SolarPanelProduction");
     }
 
-    public float getConsumption(int hour) {
+    public float getBaseConsumption(int hour) {
         return dayProfile.getValue(hour, "HouseBaseConsumption");
+    }
+
+    public float getHeatPumpConsumption(int hour) {
+        return dayProfile.getValue(hour, "HeatPumpConsumption");
+    }
+
+    public float getElectricVehicleConsumption(int hour) {
+        return dayProfile.getValue(hour, "ElectricVehicleConsumption");
     }
 
     public Electricity getCurrent(int hour) {
         float production = getSolarPanelOutput(hour);
-        float consumption = getConsumption(hour);
+        float consumption = getTotalConsumptionOfHour(hour);
         if (production > consumption) {
             return new Electricity(production - consumption, Direction.PRODUCTION);
         } else {
             return new Electricity(consumption - production, Direction.DEMAND);
         }
+    }
+
+    private float getTotalConsumptionOfHour(int hour) {
+        float total = getBaseConsumption(hour);
+        total += houseOptions.hasHeatpump() ? getHeatPumpConsumption(hour) : 0;
+        total += houseOptions.hasElectricVehicle() ? getElectricVehicleConsumption(hour) : 0;
+        return total;
     }
 
     public int getTotalSolarPanels() {

--- a/back-end/src/main/java/nl/hu/serious_game/domain/House.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/House.java
@@ -5,16 +5,16 @@ import java.util.ArrayList;
 public class House implements Cloneable {
     private int id;
     private float maxCurrent;
-    private boolean hasHeatpump;
-    private boolean hasElectricVehicle;
     private int totalSolarPanels;
     private ArrayList<Battery> batteries;
     private DayProfile dayProfile;
+    private HouseOptions houseOptions;
 
-    public House (int id, int totalSolarPanels, DayProfile dayProfile) {
+    public House (int id, int totalSolarPanels, DayProfile dayProfile, HouseOptions houseOptions) {
         this.id = id;
         this.totalSolarPanels = totalSolarPanels;
         this.dayProfile = dayProfile;
+        this.houseOptions = houseOptions;
     }
 
     public void addSolarPanel(int amount) {

--- a/back-end/src/main/java/nl/hu/serious_game/domain/HouseOptions.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/HouseOptions.java
@@ -1,0 +1,39 @@
+package nl.hu.serious_game.domain;
+
+import java.util.Objects;
+
+public class HouseOptions {
+    private boolean hasHeatPump;
+    private boolean hasElectricVehicle;
+
+    public HouseOptions() {
+        this.hasHeatPump = false;
+        this.hasElectricVehicle = false;
+    }
+
+    public HouseOptions(boolean hasHeatPump, boolean hasElectricVehicle) {
+        this.hasHeatPump = hasHeatPump;
+        this.hasElectricVehicle = hasElectricVehicle;
+    }
+
+    public boolean hasHeatpump() {
+        return hasHeatPump;
+    }
+
+    public boolean hasElectricVehicle() {
+        return hasElectricVehicle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HouseOptions that = (HouseOptions) o;
+        return hasHeatPump == that.hasHeatPump && hasElectricVehicle == that.hasElectricVehicle;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hasHeatPump, hasElectricVehicle);
+    }
+}

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Season.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Season.java
@@ -1,17 +1,19 @@
 package nl.hu.serious_game.domain;
 
 public enum Season {
-    SPRING(0.89f, 1.25f),
-    SUMMER(1f, 1f),
-    AUTUMN(0.54f, 1.25f),
-    WINTER(0.27f, 1.5f);
+    SPRING(0.89f, 1.25f, 1.19f),
+    SUMMER(1f, 1f, 1f),
+    AUTUMN(0.54f, 1.25f, 1.63f),
+    WINTER(0.27f, 1.5f, 2f);
 
     private final float solarPanelFactor;
     private final float houseBaseConsumptionFactor;
+    private final float HeatPumpFactor;
 
-    Season(float solarPanelFactor, float houseBaseConsumptionFactor) {
+    Season(float solarPanelFactor, float houseBaseConsumptionFactor, float HeatPumpFactor) {
         this.solarPanelFactor = solarPanelFactor;
         this.houseBaseConsumptionFactor = houseBaseConsumptionFactor;
+        this.HeatPumpFactor = HeatPumpFactor;
     }
 
     public float getSolarPanelFactor() {
@@ -20,5 +22,9 @@ public enum Season {
 
     public float getHouseBaseConsumptionFactor() {
         return houseBaseConsumptionFactor;
+    }
+
+    public float getHeatPumpConsumptionFactor() {
+        return HeatPumpFactor;
     }
 }

--- a/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseConsumptionTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseConsumptionTest.java
@@ -54,4 +54,57 @@ public class HouseConsumptionTest {
                 Arguments.of(Season.AUTUMN, 0, 0.34625f)
         );
     }
+
+    // Parameterized test for checking the house consumption for different options
+    // (electric vehicle and heatpump) and hours
+    // Heatpump has a consumption of 0.1825 throughout the day
+    // Electric vehicle has a consumption of 0.36 between 19:00 and 07:00 the next day
+    @ParameterizedTest
+    @DisplayName("House Consumption Test with options")
+    @MethodSource("provideHouseConsumptionOptionsAndTimeExamples")
+    public void HouseConsumptionTestOptions(Season season, boolean hasElectricVehicle, boolean hasHeatPump, int hour, float expectedOutput) {
+        House house = new House(1, 1, new DayProfile(season), new HouseOptions(hasHeatPump, hasElectricVehicle));
+        assertEquals(expectedOutput, house.getTotalConsumptionOfHour(hour));
+    }
+
+    // Source of arguments for the parameterized test, containing: Season, Electric vehicle, Heat pump, Hour, Expected output
+    private static Stream<Arguments> provideHouseConsumptionOptionsAndTimeExamples() {
+        return Stream.of(
+                // Tests for when electric vehicle will not consume due to the hour
+                Arguments.of(Season.SUMMER, false, false, 12, 0.39f),
+                Arguments.of(Season.SUMMER, true, false, 12, 0.39f),
+                Arguments.of(Season.SUMMER, false, true, 12, 0.5725f),
+                Arguments.of(Season.SUMMER, true, true, 12, 0.5725f),
+                Arguments.of(Season.WINTER, false, false, 12, 0.585f),
+                Arguments.of(Season.WINTER, true, false, 12, 0.585f),
+                Arguments.of(Season.WINTER, false, true, 12, 0.95f),
+                Arguments.of(Season.WINTER, true, true, 12, 0.95f),
+                Arguments.of(Season.SPRING, false, false, 12, 0.48749998f),
+                Arguments.of(Season.SPRING, true, false, 12, 0.48749998f),
+                Arguments.of(Season.SPRING, false, true, 12, 0.704675f),
+                Arguments.of(Season.SPRING, true, true, 12, 0.704675f),
+                Arguments.of(Season.AUTUMN, false, false, 12, 0.48749998f),
+                Arguments.of(Season.AUTUMN, true, false, 12, 0.48749998f),
+                Arguments.of(Season.AUTUMN, false, true, 12, 0.784975f),
+                Arguments.of(Season.AUTUMN, true, true, 12, 0.784975f),
+
+                // Same tests, but for when electric vehicle will also consume
+                Arguments.of(Season.SUMMER, false, false, 0, 0.277f),
+                Arguments.of(Season.SUMMER, true, false, 0, 0.637f),
+                Arguments.of(Season.SUMMER, false, true, 0, 0.4595f),
+                Arguments.of(Season.SUMMER, true, true, 0, 0.8195f),
+                Arguments.of(Season.WINTER, false, false, 0, 0.41550002f),
+                Arguments.of(Season.WINTER, true, false, 0, 0.77550006f),
+                Arguments.of(Season.WINTER, false, true, 0, 0.78050005f),
+                Arguments.of(Season.WINTER, true, true, 0, 1.1405001f),
+                Arguments.of(Season.SPRING, false, false, 0, 0.34625f),
+                Arguments.of(Season.SPRING, true, false, 0, 0.70625f),
+                Arguments.of(Season.SPRING, false, true, 0, 0.563425f),
+                Arguments.of(Season.SPRING, true, true, 0, 0.923425f),
+                Arguments.of(Season.AUTUMN, false, false, 0, 0.34625f),
+                Arguments.of(Season.AUTUMN, true, false, 0, 0.70625f),
+                Arguments.of(Season.AUTUMN, false, true, 0, 0.64372504f),
+                Arguments.of(Season.AUTUMN, true, true, 0, 1.003725f)
+        );
+    }
 }

--- a/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseConsumptionTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseConsumptionTest.java
@@ -2,6 +2,7 @@ package nl.hu.serious_game.domain.HouseTest;
 
 import nl.hu.serious_game.domain.DayProfile;
 import nl.hu.serious_game.domain.House;
+import nl.hu.serious_game.domain.HouseOptions;
 import nl.hu.serious_game.domain.Season;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +28,8 @@ public class HouseConsumptionTest {
     @Test
     @DisplayName("House Consumption Test 12:00")
     public void HouseConsumptionTestHour12() {
-        House house = new House(1, 1, new DayProfile(Season.SUMMER));
-        assertEquals(0.39f, house.getConsumption(12));
+        House house = new House(1, 1, new DayProfile(Season.SUMMER), new HouseOptions());
+        assertEquals(0.39f, house.getBaseConsumption(12));
     }
 
     // Parameterized test for checking the house consumption for different seasons and hours
@@ -36,8 +37,8 @@ public class HouseConsumptionTest {
     @DisplayName("Season Test house consumption")
     @MethodSource("provideHouseConsumptionSeasonAndTimeExamples")
     public void SeasonTestHouseConsumption(Season season, int hour, float expectedOutput) {
-        House house = new House(1, 1, new DayProfile(season));
-        assertEquals(expectedOutput, house.getConsumption(hour));
+        House house = new House(1, 1, new DayProfile(season), new HouseOptions());
+        assertEquals(expectedOutput, house.getBaseConsumption(hour));
     }
 
     // Source of arguments for the parameterized test, containing: Season, Hour, Expected output

--- a/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseCurrentTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseCurrentTest.java
@@ -1,9 +1,6 @@
 package nl.hu.serious_game.domain.HouseTest;
 
-import nl.hu.serious_game.domain.DayProfile;
-import nl.hu.serious_game.domain.Direction;
-import nl.hu.serious_game.domain.House;
-import nl.hu.serious_game.domain.Season;
+import nl.hu.serious_game.domain.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +21,7 @@ public class HouseCurrentTest {
     @DisplayName("Summer Test with 14 solar panels, house producing more than consuming")
     public void SummerTest14SolarPanels() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 14, dayProfile);
+        House house = new House(1, 14, dayProfile, new HouseOptions());
 
         assertAll(
             () -> assertEquals(Direction.PRODUCTION, house.getCurrent(12).direction()),
@@ -40,7 +37,7 @@ public class HouseCurrentTest {
     @DisplayName("Summer Test with 1 solar panel, house consuming more than producing")
     public void SummerTest1SolarPanel() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
 
         assertAll(
             () -> assertEquals(Direction.DEMAND, house.getCurrent(12).direction()),

--- a/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseSolarPanelTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/HouseTest/HouseSolarPanelTest.java
@@ -2,6 +2,7 @@ package nl.hu.serious_game.domain.HouseTest;
 
 import nl.hu.serious_game.domain.DayProfile;
 import nl.hu.serious_game.domain.House;
+import nl.hu.serious_game.domain.HouseOptions;
 import nl.hu.serious_game.domain.Season;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +26,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Summer Test with one solar panel")
     public void SummerTestOneSolarPanel() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertEquals(0.196428571f, house.getSolarPanelOutput(12));
     }
 
@@ -35,7 +36,7 @@ public class HouseSolarPanelTest {
     @MethodSource("provideSolarPanelSeasonAndTimeExamples")
     public void SeasonTestOneSolarPanel(Season season, int hour, float expectedOutput) {
         DayProfile dayProfile = new DayProfile(season);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertEquals(expectedOutput, house.getSolarPanelOutput(hour));
     }
 
@@ -63,7 +64,7 @@ public class HouseSolarPanelTest {
     @MethodSource("provideSolarPanelAmountExamples")
     public void SolarPanelAmountTest(int solarPanelAmount, int hour, float expectedOutput) {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, solarPanelAmount, dayProfile);
+        House house = new House(1, solarPanelAmount, dayProfile, new HouseOptions());
         assertEquals(expectedOutput, house.getSolarPanelOutput(hour));
     }
 
@@ -84,7 +85,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Invalid Hour Test")
     public void InvalidHourTest() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertThrows(IllegalArgumentException.class, () -> house.getSolarPanelOutput(24));
     }
 
@@ -93,7 +94,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Add Negative Solar Panel Amount Test")
     public void AddNegativeSolarPanelAmountTest() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertThrows(IllegalArgumentException.class, () -> house.addSolarPanel(-1));
     }
 
@@ -102,7 +103,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Remove Negative Solar Panel Amount Test")
     public void RemoveNegativeSolarPanelAmountTest() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertThrows(IllegalArgumentException.class, () -> house.removeSolarPanel(-1));
     }
 
@@ -111,7 +112,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Remove More Solar Panels Than There Are Test")
     public void RemoveMoreSolarPanelsThanThereAreTest() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         assertThrows(IllegalArgumentException.class, () -> house.removeSolarPanel(2));
     }
 
@@ -120,7 +121,7 @@ public class HouseSolarPanelTest {
     @DisplayName("Remove Right Amount Of Solar Panels Test")
     public void RemoveRightAmountOfSolarPanelsTest() {
         DayProfile dayProfile = new DayProfile(Season.SUMMER);
-        House house = new House(1, 1, dayProfile);
+        House house = new House(1, 1, dayProfile, new HouseOptions());
         house.removeSolarPanel(1);
         assertEquals(0, house.getTotalSolarPanels());
     }


### PR DESCRIPTION
### Domein
- Boolean attributen vervangen met een value object voor een huis (inclusief default constructor met "false" als defaults), waarbij het gebruik van het huis constructor ook in de tests en runner aangepast zijn
- DayProfile uitgebreid met data voor elektrische auto's en warmtepompen
- Domein uitgebreid met logica voor consumptie wanneer een huis wel of geen elektrische auto en/of warmtepomp heeft
- Factoren toegevoegd voor Warmtepompen in Enum

### Tests
- Tests toegevoegd voor het testen van totale huis consumptie met opties zoals warmtepomp en elektrische auto

### Runner en Service
- Initialisatie van level 2 toegevoegd in runner en optie in service toegevoegd