### PR TITLE
T 265 en T 266 - popup connection transformer

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
@@ -22,8 +22,8 @@ public class LevelService {
 
     public LevelDTO startLevel(int levelNumber) {
         Level level = switch (levelNumber) {
-            case 1 -> runner.getLevel1();
-            case 2 -> runner.getLevel2();
+            case 1 -> runner.getLevel1().clone();
+            case 2 -> runner.getLevel2().clone();
             default -> throw new IllegalArgumentException("Invalid level number");
         };
         return runLevel(level);

--- a/front-end/src/components/PopupComponent.vue
+++ b/front-end/src/components/PopupComponent.vue
@@ -102,6 +102,10 @@
               >
               <v-col cols="2" class="text-end highlight">{{ batteries }}</v-col>
             </v-row>
+            <v-row>
+              <v-col cols="6"><strong>Totale accu lading:</strong></v-col>
+              <v-col cols="6" class="text-end highlight">{{ formattedBatteryCharge }} kWh</v-col>
+            </v-row>
           </div>
         </v-container>
       </v-card-text>
@@ -152,7 +156,11 @@ export default defineComponent({
     batteries: {
       type: Number,
       default: 0
-    }
+    },
+    batteryCharge: {
+      type: Number,
+      default: 0
+    },
   },
   setup(props, { emit }) {
     const energyDifference = computed(
@@ -165,6 +173,10 @@ export default defineComponent({
 
     const formattedEnergyConsumption = computed(() => {
       return props.energyConsumption.toFixed(2);
+    });
+
+    const formattedBatteryCharge = computed(() => {
+      return props.batteryCharge.toFixed(2);
     });
 
     const heatPumpDisplay = computed(() => props.heatPump ? '✔️' : '❌');
@@ -194,6 +206,7 @@ export default defineComponent({
       energyDifference,
       formattedEnergyProduction,
       formattedEnergyConsumption,
+      formattedBatteryCharge,
       heatPumpDisplay,
       electricVehicleDisplay,
       energyConsumptionLabel,

--- a/front-end/src/components/PopupComponent.vue
+++ b/front-end/src/components/PopupComponent.vue
@@ -171,11 +171,11 @@ export default defineComponent({
     const electricVehicleDisplay = computed(() => props.electricVehicle ? '✔️' : '❌');
 
     const energyProductionLabel = computed(() => {
-      return props.type === 'transformator' ? 'Energie vanuit huizen ontvangen' : 'Energie productie';
+      return props.type === 'transformator' ? 'Energie om terug te leveren aan net' : 'Energie productie';
     });
 
     const energyConsumptionLabel = computed(() => {
-      return props.type === 'transformator' ? 'Energie aan huizen geleverd' : 'Energie consumptie';
+      return props.type === 'transformator' ? 'Energie aan huizen vanuit net' : 'Energie consumptie';
     });
 
     const increaseValue = (property: string) => {

--- a/front-end/src/components/PopupComponent.vue
+++ b/front-end/src/components/PopupComponent.vue
@@ -19,13 +19,13 @@
           <!-- Energie Overzicht -->
           <div class="section energy-section">
             <v-row>
-              <v-col cols="6"><strong>Energie productie:</strong></v-col>
+              <v-col cols="6"><strong>{{ energyProductionLabel}}:</strong></v-col>
               <v-col cols="6" class="text-end highlight"
                 >{{ formattedEnergyProduction }} kWh</v-col
               >
             </v-row>
             <v-row>
-              <v-col cols="6"><strong>Energie consumptie:</strong></v-col>
+              <v-col cols="6"><strong>{{  energyConsumptionLabel }}:</strong></v-col>
               <v-col cols="6" class="text-end highlight"
                 >{{ formattedEnergyConsumption }} kWh</v-col
               >
@@ -170,6 +170,14 @@ export default defineComponent({
     const heatPumpDisplay = computed(() => props.heatPump ? '✔️' : '❌');
     const electricVehicleDisplay = computed(() => props.electricVehicle ? '✔️' : '❌');
 
+    const energyProductionLabel = computed(() => {
+      return props.type === 'transformator' ? 'Energie vanuit huizen ontvangen' : 'Energie productie';
+    });
+
+    const energyConsumptionLabel = computed(() => {
+      return props.type === 'transformator' ? 'Energie aan huizen geleverd' : 'Energie consumptie';
+    });
+
     const increaseValue = (property: string) => {
       emit('increase', property);
     };
@@ -188,6 +196,8 @@ export default defineComponent({
       formattedEnergyConsumption,
       heatPumpDisplay,
       electricVehicleDisplay,
+      energyConsumptionLabel,
+      energyProductionLabel,
       increaseValue,
       decreaseValue,
       closeDialog,

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -110,6 +110,15 @@ export default defineComponent({
       isPopupOpen.value = true;
     };
 
+    const showTransformerDetails = (transformer: { id: number, current: { amount: number, direction: string }, batteries: { amount: number } }) => {
+      popupTitle.value = `Transformator ${transformer.id}`;
+      popupType.value = 'transformator';
+      popupEnergyProduction.value = transformer.current.direction === 'PRODUCTION' ? transformer.current.amount : 0;
+      popupEnergyConsumption.value = transformer.current.direction === 'DEMAND' ? transformer.current.amount : 0;
+      popupBatteries.value = transformer.batteries.amount;
+      isPopupOpen.value = true;
+    };
+
     const updateSolarPanels = (newValue: number) => {
       const house = transformers.value.flatMap(t => t.houses).find(h => h.id === parseInt(popupTitle.value.split(' ')[1]));
       if (house) {
@@ -195,6 +204,7 @@ export default defineComponent({
       popupSolarPanels,
       popupBatteries,
       showHouseDetails,
+      showTransformerDetails,
       updateSolarPanels,
       handleIncrease,
       handleDecrease,

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -16,11 +16,11 @@
       </template>
       <template v-for="transformer in transformers">
         <transformer
-          v-for="transformer in transformers"
-          :key="'transformer-' + transformer.id"
-          :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 'px' }"
-          @click="showTransformerDetails(transformer)"
-          :hasBatteries="transformer.batteries.amount > 0"
+            v-for="transformer in transformers"
+            :key="'transformer-' + transformer.id"
+            :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 'px' }"
+            @click="showTransformerDetails(transformer)"
+            :hasBatteries="transformer.batteries.amount > 0"
         />
         <House
             v-for="house in transformer.houses"
@@ -45,6 +45,7 @@
         :electricVehicle="popupElectricVehicle"
         :solarPanels="popupSolarPanels"
         :batteries="popupBatteries"
+        :batteryCharge="popupBatteryCharge"
         @update:isOpen="isPopupOpen = $event"
         @increase="handleIncrease"
         @decrease="handleDecrease"
@@ -79,7 +80,7 @@ export default defineComponent({
     const gameCanvas = ref<HTMLDivElement | null>(null);
     const transformerPositions = ref<number[]>([]);
     const housePositions = ref<number[]>([]);
-    const transformers = ref<{ id: number, batteries: number, houses: { id: number, batteries: number, solarpanels: number, hasCongestion: boolean, maxCurrent: number, hasElectricVehicle: boolean, hasHeatpump: boolean }[] }[]>([]);
+    const transformers = ref<{ id: number, batteries: { amount: number, totalCharge: number }, houses: { id: number, batteries: { amount: number, currentCharge: number }, solarpanels: number, hasCongestion: boolean, maxCurrent: number, hasElectricVehicle: boolean, hasHeatpump: boolean }[] }[]>([]);
 
     const isPopupOpen = ref(false);
     const popupTitle = ref('');
@@ -90,6 +91,7 @@ export default defineComponent({
     const popupElectricVehicle = ref(false);
     const popupSolarPanels = ref(0);
     const popupBatteries = ref(0);
+    const popupBatteryCharge = ref(0);
 
     const generatePositions = (count: number, start: number): number[] => {
       const positions = [];
@@ -99,7 +101,7 @@ export default defineComponent({
       return positions;
     };
 
-    const showHouseDetails = (house: { id: number, batteries: { amount: number}, solarpanels: number, production: number, consumption: number, hasHeatpump: boolean, hasElectricVehicle: boolean }) => {
+    const showHouseDetails = (house: { id: number, batteries: { amount: number, totalCharge: number }, solarpanels: number, production: number, consumption: number, hasHeatpump: boolean, hasElectricVehicle: boolean }) => {
       popupTitle.value = `Huis ${house.id}`;
       popupType.value = 'huis';
       popupEnergyProduction.value = house.production;
@@ -108,15 +110,17 @@ export default defineComponent({
       popupElectricVehicle.value = house.hasElectricVehicle;
       popupSolarPanels.value = house.solarpanels;
       popupBatteries.value = house.batteries.amount;
+      popupBatteryCharge.value = house.batteries.totalCharge;
       isPopupOpen.value = true;
     };
 
-    const showTransformerDetails = (transformer: { id: number, current: { amount: number, direction: string }, batteries: { amount: number } }) => {
+    const showTransformerDetails = (transformer: { id: number, current: { amount: number, direction: string }, batteries: { amount: number, totalCharge: number } }) => {
       popupTitle.value = `Transformator ${transformer.id}`;
       popupType.value = 'transformator';
       popupEnergyProduction.value = transformer.current.direction === 'PRODUCTION' ? transformer.current.amount : 0;
       popupEnergyConsumption.value = transformer.current.direction === 'DEMAND' ? transformer.current.amount : 0;
       popupBatteries.value = transformer.batteries.amount;
+      popupBatteryCharge.value = transformer.batteries.totalCharge;
       isPopupOpen.value = true;
     };
 
@@ -212,6 +216,7 @@ export default defineComponent({
       popupElectricVehicle,
       popupSolarPanels,
       popupBatteries,
+      popupBatteryCharge,
       showHouseDetails,
       showTransformerDetails,
       updateSolarPanels,

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -20,7 +20,7 @@
           :key="'transformer-' + transformer.id"
           :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 'px' }"
           @click="showTransformerDetails(transformer)"
-          :hasBatteries="transformer.batteries > 0"
+          :hasBatteries="transformer.batteries.amount > 0"
         />
         <House
             v-for="house in transformer.houses"
@@ -30,7 +30,7 @@
             :hasElectricCar="house.hasElectricVehicle"
             :hasHeatPump="house.hasHeatpump"
             :hasSolarPanels="house.solarpanels > 0"
-            :hasBatteries="house.batteries > 0"
+            :hasBatteries="house.batteries.amount > 0"
         />
       </template>
     </div>
@@ -79,7 +79,7 @@ export default defineComponent({
     const gameCanvas = ref<HTMLDivElement | null>(null);
     const transformerPositions = ref<number[]>([]);
     const housePositions = ref<number[]>([]);
-    const transformers = ref<{ id: number, houses: { id: number, batteries: number, solarpanels: number, hasCongestion: boolean, maxCurrent: number, hasElectricVehicle: boolean, hasHeatpump: boolean }[] }[]>([]);
+    const transformers = ref<{ id: number, batteries: number, houses: { id: number, batteries: number, solarpanels: number, hasCongestion: boolean, maxCurrent: number, hasElectricVehicle: boolean, hasHeatpump: boolean }[] }[]>([]);
 
     const isPopupOpen = ref(false);
     const popupTitle = ref('');
@@ -99,7 +99,7 @@ export default defineComponent({
       return positions;
     };
 
-    const showHouseDetails = (house: { id: number, batteries: number, solarpanels: number, production: number, consumption: number, hasHeatpump: boolean, hasElectricVehicle: boolean }) => {
+    const showHouseDetails = (house: { id: number, batteries: { amount: number}, solarpanels: number, production: number, consumption: number, hasHeatpump: boolean, hasElectricVehicle: boolean }) => {
       popupTitle.value = `Huis ${house.id}`;
       popupType.value = 'huis';
       popupEnergyProduction.value = house.production;
@@ -128,9 +128,16 @@ export default defineComponent({
     };
 
     const updateBatteries = (newValue: number) => {
-      const house = transformers.value.flatMap(t => t.houses).find(h => h.id === parseInt(popupTitle.value.split(' ')[1]));
-      if (house) {
-        house.batteries.amount = newValue;
+      if (popupType.value === 'huis') {
+        const house = transformers.value.flatMap(t => t.houses).find(h => h.id === parseInt(popupTitle.value.split(' ')[1]));
+        if (house) {
+          house.batteries.amount = newValue;
+        }
+      } else if (popupType.value === 'transformator') {
+        const transformer = transformers.value.find(t => t.id === parseInt(popupTitle.value.split(' ')[1]));
+        if (transformer) {
+          transformer.batteries.amount = newValue;
+        }
       }
     };
 
@@ -159,6 +166,7 @@ export default defineComponent({
         const data = {
           transformers: transformers.value.map(transformer => ({
             id: transformer.id,
+            batteries: transformer.batteries.amount,
             houses: transformer.houses.map(house => ({
               id: house.id,
               batteries: house.batteries.amount,

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -14,12 +14,14 @@
             :maxCurrent="house.maxCurrent"
         />
       </template>
-      <Transformer
-          v-for="(pos, index) in transformerPositions"
-          :key="'transformer-' + index"
-          :style="{ position: 'absolute', left: (pos % 10) * 150 + 'px', top: Math.floor(pos / 10) * 80 + 'px' }"
-      />
       <template v-for="transformer in transformers">
+        <transformer
+          v-for="transformer in transformers"
+          :key="'transformer-' + transformer.id"
+          :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 'px' }"
+          @click="showTransformerDetails(transformer)"
+          :hasBatteries="transformer.batteries > 0"
+        />
         <House
             v-for="house in transformer.houses"
             :key="'house-' + house.id"

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -101,6 +101,7 @@ export default defineComponent({
 
     const showHouseDetails = (house: { id: number, batteries: number, solarpanels: number, production: number, consumption: number, hasHeatpump: boolean, hasElectricVehicle: boolean }) => {
       popupTitle.value = `Huis ${house.id}`;
+      popupType.value = 'huis';
       popupEnergyProduction.value = house.production;
       popupEnergyConsumption.value = house.consumption;
       popupHeatPump.value = house.hasHeatpump;


### PR DESCRIPTION
This pull request includes several changes to the `LevelService` class, the `PopupComponent.vue` component, and the `Level.vue` page to enhance functionality and improve the user interface. The most significant changes involve cloning levels in the backend, adding battery charge details in the frontend, and updating the transformer and house details.

### Backend changes:
* [`back-end/src/main/java/nl/hu/serious_game/application/LevelService.java`](diffhunk://#diff-097c225a1fd3ec21706dd19d9b701f56ce088ce97c75a21c45f0980cbb3e088dL25-R26): Modified the `startLevel` method to clone levels when starting a new level.

### Frontend changes:
* [`front-end/src/components/PopupComponent.vue`](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L22-R28): Added new properties and computed methods to display battery charge details and dynamically change energy labels based on the type. [[1]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L22-R28) [[2]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955R105-R108) [[3]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L155-R163) [[4]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955R178-R192) [[5]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955R209-R213)
* [`front-end/src/pages/Level.vue`](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L17-R24): Updated the `Level.vue` page to handle transformer and house details more comprehensively, including battery charge information and dynamic positioning of transformers. [[1]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L17-R24) [[2]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L31-R33) [[3]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R48) [[4]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L80-R83) [[5]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R94) [[6]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L100-R123) [[7]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R135-R145) [[8]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R173) [[9]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R219-R221)