### PR TITLE
Level visuals - Congestie, positionering, schaal

### DIFF
--- a/front-end/src/components/ConnectionLine.vue
+++ b/front-end/src/components/ConnectionLine.vue
@@ -1,14 +1,53 @@
 <template>
-  <svg :width="width" :height="height" xmlns="http://www.w3.org/2000/svg" style="position: absolute; top: 0; left: 0;">
-    <line :x1="x1" :y1="y1" :x2="x2" :y2="y2" stroke="black" stroke-width="2" />
-    <text v-if="hasCongestion" :x="(x1 + x2) / 2" :y="(y1 + y2) / 2" :transform="rotationTransform" fill="red">
-      Congestie: {{ maxCurrent }}kW
-    </text>
-  </svg>
+  <div>
+    <svg :width="width" :height="height" xmlns="http://www.w3.org/2000/svg" style="position: absolute; top: 0; left: 0;">
+      <text class="congestion-text-indicator" v-if="hasCongestion" :x="(x1 + x2) / 2" :y="(y1 + y2) / 2" :transform="rotationTransform" fill="red">
+        Congestie
+      </text>
+      <!-- Visible line -->
+      <line
+          :x1="x1"
+          :y1="y1"
+          :x2="x2"
+          :y2="y2"
+          stroke="black"
+          stroke-width="2"
+      />
+      <!-- Invisible line with margin for easier hovering -->
+      <line class="infoBox-trigger"
+          :x1="x1"
+          :y1="y1"
+          :x2="x2"
+          :y2="y2"
+          stroke="transparent"
+          stroke-width="30"
+          @mouseover="showInfoBox"
+          @mouseout="hideInfoBox"
+      />
+    </svg>
+    <div v-if="infoBoxVisible" :style="infoBoxStyle" class="infoBox">
+      {{ infoBoxContents }}
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
+  data() {
+    return {
+      infoBoxVisible: false,
+      infoBoxStyle: {
+        position: 'absolute',
+        top: '0px',
+        left: '0px',
+        backgroundColor: '#333',
+        color: '#fff',
+        padding: '5px',
+        borderRadius: '3px',
+        pointerEvents: 'none',
+      },
+    };
+  },
   props: {
     x1: {
       type: Number,
@@ -52,6 +91,30 @@ export default {
       const cy = (this.y1 + this.y2) / 2;
       return `rotate(${angle}, ${cx}, ${cy})`;
     },
+    infoBoxContents() {
+      return `Congestie: ${this.maxCurrent}kW`;
+    },
+  },
+  methods: {
+    showInfoBox(event) {
+      this.infoBoxVisible = true;
+      this.infoBoxStyle.top = `${event.clientY + 10}px`;
+      this.infoBoxStyle.left = `${event.clientX + 10}px`;
+    },
+    hideInfoBox() {
+      this.infoBoxVisible = false;
+    },
   },
 };
 </script>
+
+<style scoped>
+.infoBox-trigger {
+  cursor: help;
+  z-index: 1000;
+}
+.infoBox {
+  font-size: 14px;
+  z-index: 1000;
+}
+</style>

--- a/front-end/src/components/ConnectionLine.vue
+++ b/front-end/src/components/ConnectionLine.vue
@@ -4,25 +4,33 @@
       <text class="congestion-text-indicator" v-if="hasCongestion" :x="(x1 + x2) / 2" :y="(y1 + y2) / 2" :transform="rotationTransform" fill="red">
         Congestie
       </text>
-      <!-- Visible line -->
+      <!-- Line with inner and outer colors -->
       <line
           :x1="x1"
           :y1="y1"
           :x2="x2"
           :y2="y2"
           stroke="black"
-          stroke-width="2"
+          stroke-width="6"
       />
-      <!-- Invisible line with margin for easier hovering -->
-      <line class="infoBox-trigger"
+      <line
           :x1="x1"
           :y1="y1"
           :x2="x2"
           :y2="y2"
-          stroke="transparent"
-          stroke-width="30"
-          @mouseover="showInfoBox"
-          @mouseout="hideInfoBox"
+          :stroke="innerLineColor"
+          stroke-width="2"
+      />
+      <!-- Invisible line with margin for easier hovering -->
+      <line class="infoBox-trigger"
+            :x1="x1"
+            :y1="y1"
+            :x2="x2"
+            :y2="y2"
+            stroke="transparent"
+            stroke-width="30"
+            @mouseover="showInfoBox"
+            @mouseout="hideInfoBox"
       />
     </svg>
     <div v-if="infoBoxVisible" :style="infoBoxStyle" class="infoBox">
@@ -84,15 +92,20 @@ export default {
   },
   computed: {
     rotationTransform() {
+      const marginX = 15;
+      const marginY = 15;
       const dx = this.x2 - this.x1;
       const dy = this.y2 - this.y1;
       const angle = Math.atan2(dy, dx) * (180 / Math.PI);
-      const cx = (this.x1 + this.x2) / 2;
-      const cy = (this.y1 + this.y2) / 2;
+      const cx = (this.x1 + this.x2) / 2 + marginX;
+      const cy = (this.y1 + this.y2) / 2 - marginY;
       return `rotate(${angle}, ${cx}, ${cy})`;
     },
     infoBoxContents() {
       return `Congestie: ${this.maxCurrent}kW`;
+    },
+    innerLineColor() {
+      return this.hasCongestion ? 'red' : 'white';
     },
   },
   methods: {

--- a/front-end/src/components/Transformer.vue
+++ b/front-end/src/components/Transformer.vue
@@ -47,11 +47,11 @@ export default {
   props: {
     width: {
       type: Number,
-      default: 200,
+      default: 100,
     },
     height: {
       type: Number,
-      default: 250,
+      default: 125,
     },
     hasBatteries: {
       type: Boolean,

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -6,10 +6,10 @@
         <ConnectionLine
             v-for="house in transformer.houses"
             :key="'connection-' + house.id"
-            :x1="(transformerPositions[transformer.id - 1] % 10) * 150 + 100"
+            :x1="(transformerPositions[transformer.id - 1] % 10) * 150 + 350"
             :y1="Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 125"
             :x2="(housePositions[house.id - 1] % 10) * 150 + 100"
-            :y2="Math.floor(housePositions[house.id - 1] / 10) * 80 + 130"
+            :y2="Math.floor(housePositions[house.id - 1] / 10) * 80 + 60"
             :hasCongestion="house.hasCongestion"
             :maxCurrent="house.maxCurrent"
         />
@@ -18,7 +18,7 @@
         <transformer
             v-for="transformer in transformers"
             :key="'transformer-' + transformer.id"
-            :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 'px' }"
+            :style="{ position: 'absolute', left: (transformerPositions[transformer.id - 1] % 10) * 150 + 300 + 'px', top: Math.floor(transformerPositions[transformer.id - 1] / 10) * 80 + 30 + 'px' }"
             @click="showTransformerDetails(transformer)"
             :hasBatteries="transformer.batteries.amount > 0"
         />


### PR DESCRIPTION
This pull request includes several enhancements and adjustments to the front-end components, primarily focusing on the `ConnectionLine.vue` component, as well as changes to the `Transformer.vue` component and positioning adjustments in `Level.vue`. The most important changes include the addition of an information box on hover, modifications to the connection line rendering, and adjustments to the transformer and house positions.

![image](https://i.imgur.com/YdSSd6R.gif)

Enhancements to `ConnectionLine.vue`:

* Added an information box that appears on hover, displaying congestion details. (`front-end/src/components/ConnectionLine.vue`, [front-end/src/components/ConnectionLine.vueR2-R58](diffhunk://#diff-8efe3c6c80d8695f7d9766d03271445cf72178c9d178ae5cc1561260aae816d9R2-R58))
* Modified the connection line rendering to include an inner line color that changes based on congestion status, and added an invisible line for easier hovering. (`front-end/src/components/ConnectionLine.vue`, [front-end/src/components/ConnectionLine.vueR2-R58](diffhunk://#diff-8efe3c6c80d8695f7d9766d03271445cf72178c9d178ae5cc1561260aae816d9R2-R58))
* Updated the `rotationTransform` computation to include margins for better positioning of the congestion text. (`front-end/src/components/ConnectionLine.vue`, [front-end/src/components/ConnectionLine.vueR95-R133](diffhunk://#diff-8efe3c6c80d8695f7d9766d03271445cf72178c9d178ae5cc1561260aae816d9R95-R133))

Adjustments to `Transformer.vue`:

* Changed the default width and height properties of the transformer component to smaller values. (`front-end/src/components/Transformer.vue`, [front-end/src/components/Transformer.vueL50-R54](diffhunk://#diff-63234424a43a46de0e5ce5ec7f89df5f63e1e5afd5930fcdecbc8a1f9e485d52L50-R54))

Positioning updates in `Level.vue`:

* Adjusted the positions of connection lines and transformers to new coordinates for better layout. (`front-end/src/pages/Level.vue`, [[1]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L9-R12) [[2]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972L21-R21)