### PR TITLE
T 291 - Het bepalen van munt kosten van Zonnepanelen en Thuisaccu's op back-end niveau + weergeven op front-end

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/Runner.java
+++ b/back-end/src/main/java/nl/hu/serious_game/Runner.java
@@ -35,7 +35,7 @@ public class Runner implements CommandLineRunner {
         // Create a single transformer
         Transformer transformer = new Transformer(1, List.of(house, house2), 1);
 
-        Level level = new Level(Season.SUMMER, 12, 15, objective, List.of(transformer));
+        Level level = new Level(Season.SUMMER, 12, 15, objective, List.of(transformer), new Cost(5, 10));
 
         System.out.println("Level 1 created!");
         System.out.println(level);
@@ -59,7 +59,7 @@ public class Runner implements CommandLineRunner {
         // Create a single transformer
         Transformer transformer = new Transformer(1, List.of(house, house2, house3), 1);
 
-        Level level = new Level(Season.SUMMER, 12, 15, objective, List.of(transformer));
+        Level level = new Level(Season.SUMMER, 12, 15, objective, List.of(transformer), new Cost(5, 10));
 
         System.out.println("Level 2 created!");
         System.out.println(level);

--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelService.java
@@ -109,7 +109,7 @@ public class LevelService {
         Season season = level.getSeason();
         ObjectiveDTO objective = new ObjectiveDTO(level.getObjective().getMaxCo2(), level.getObjective().getMaxCoins());
 
-        return new LevelDTO(hours, season, level.getStartTime(), level.getEndTime(), objective); // Return the LevelDTO
+        return new LevelDTO(hours, season, level.getStartTime(), level.getEndTime(), objective, level.getCost()); // Return the LevelDTO
     }
 
     public int getTotalLevels() {

--- a/back-end/src/main/java/nl/hu/serious_game/application/dto/out/LevelDTO.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/dto/out/LevelDTO.java
@@ -1,5 +1,6 @@
 package nl.hu.serious_game.application.dto.out;
 
+import nl.hu.serious_game.domain.Cost;
 import nl.hu.serious_game.domain.Season;
 
 import java.util.List;
@@ -9,6 +10,7 @@ public record LevelDTO(
         Season season,
         int startTime,
         int endTime,
-        ObjectiveDTO objective
+        ObjectiveDTO objective,
+        Cost cost
 ) {}
 

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Battery.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Battery.java
@@ -11,7 +11,6 @@ public class Battery implements Cloneable {
     private float currentCharge;
     @Getter
     private float maxCharge;
-    private int coinValue;
     @Getter
     private int amount;
 

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Cost.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Cost.java
@@ -1,0 +1,40 @@
+package nl.hu.serious_game.domain;
+
+import java.util.Objects;
+
+public class Cost {
+    private final int solarPanelCost;
+    private final int batteryCost;
+
+    // Default constructor for when no specific costs are given
+    public Cost() {
+        this.solarPanelCost = 0;
+        this.batteryCost = 0;
+    }
+
+    public Cost(int solarPanelCost, int batteryCost) {
+        this.solarPanelCost = solarPanelCost;
+        this.batteryCost = batteryCost;
+    }
+
+    public int getSolarPanelCost() {
+        return solarPanelCost;
+    }
+
+    public int getBatteryCost() {
+        return batteryCost;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Cost cost = (Cost) o;
+        return solarPanelCost == cost.solarPanelCost && batteryCost == cost.batteryCost;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(solarPanelCost, batteryCost);
+    }
+}

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Level.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Level.java
@@ -11,12 +11,14 @@ public class Level implements Cloneable {
     private int endTime;
     private Objective objective;
     private List<Transformer> transformers = new ArrayList<>();
+    private Cost cost;
 
-    public Level(Season season, int startTime, int endTime, Objective objective, List<Transformer> transformers) {
+    public Level(Season season, int startTime, int endTime, Objective objective, List<Transformer> transformers, Cost cost) {
         this.season = season;
         this.startTime = startTime;
         this.endTime = endTime;
         this.objective = objective;
+        this.cost = cost;
         if (!transformers.isEmpty()) {
             this.transformers = transformers;
         } else {

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Level.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Level.java
@@ -64,6 +64,10 @@ public class Level implements Cloneable {
         return endTime;
     }
 
+    public Cost getCost() {
+        return cost;
+    }
+
     public Level clone() {
         try {
             Level clone = (Level) super.clone();

--- a/back-end/src/test/java/nl/hu/serious_game/LevelInitializationTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/LevelInitializationTest.java
@@ -46,7 +46,7 @@ public class LevelInitializationTest {
     @Test
     @DisplayName("Test level initialization")
     public void testLevelInitialization() {
-        Level level = new Level(season, startTime, endTime, objective, (List<Transformer>) transformers);
+        Level level = new Level(season, startTime, endTime, objective, (List<Transformer>) transformers, new Cost(5, 10));
 
         assertNotNull(level.getObjective(), "Objective should be initialized");
         assertEquals(objective, level.getObjective(), "Objective should match the provided value");

--- a/back-end/src/test/java/nl/hu/serious_game/application/LevelServiceTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/application/LevelServiceTest.java
@@ -21,7 +21,7 @@ public class LevelServiceTest {
     public void setUp() {
         Runner runner = mock(Runner.class);
         // Instead of creating a level, we mock one
-        when(runner.getLevel(1)).thenReturn(new Level(Season.SUMMER, 8, 18, new Objective(2, 5), List.of(new Transformer(1, List.of(), 10))));
+        when(runner.getLevel(1)).thenReturn(new Level(Season.SUMMER, 8, 18, new Objective(2, 5), List.of(new Transformer(1, List.of(), 10)), new Cost(5, 10)));
         when(runner.getTotalLevels()).thenReturn(1);
         this.levelService = new LevelService(runner);
     }

--- a/back-end/src/test/java/nl/hu/serious_game/domain/LevelTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/LevelTest.java
@@ -11,6 +11,6 @@ public class LevelTest {
     @DisplayName("Test for when transformers is empty")
     public void emptyTransformersTest() {
         Objective objective = new Objective(5, 5);
-        assertThrows(IllegalArgumentException.class, () -> new Level(Season.SUMMER, 0, 0, objective, new ArrayList<>()));
+        assertThrows(IllegalArgumentException.class, () -> new Level(Season.SUMMER, 0, 0, objective, new ArrayList<>(), new Cost(5, 10)));
     }
 }

--- a/front-end/src/components/PopupComponent.vue
+++ b/front-end/src/components/PopupComponent.vue
@@ -80,7 +80,7 @@
                 >
               </v-col>
               <v-col cols="6" class="text-center"
-              ><strong>Zonnepanelen</strong></v-col
+              ><strong>Zonnepanelen</strong> (💰{{ solarPanelCost }})</v-col
               >
               <v-col cols="2" class="text-end highlight"
               >{{ solarPanels }}</v-col
@@ -106,7 +106,7 @@
                 >
               </v-col>
               <v-col cols="6" class="text-center"
-              ><strong>Accu’s</strong></v-col
+              ><strong>Accu’s</strong> (💰{{ batteryCost }})</v-col
               >
               <v-col cols="2" class="text-end highlight">{{ batteries }}</v-col>
             </v-row>
@@ -170,6 +170,14 @@ export default defineComponent({
       default: 0
     },
     totalPowerCost: {
+      type: Number,
+      default: 0
+    },
+    solarPanelCost: {
+      type: Number,
+      default: 0
+    },
+    batteryCost: {
       type: Number,
       default: 0
     }

--- a/front-end/src/pages/Level.vue
+++ b/front-end/src/pages/Level.vue
@@ -54,6 +54,8 @@
       :batteries="popupBatteries"
       :batteryCharge="popupBatteryCharge"
       :totalPowerCost="popupTotalPowerCost"
+      :solarPanelCost="popupSolarPanelCost"
+      :batteryCost="popupBatteryCost"
       @update:isOpen="isPopupOpen = $event"
       @increase="handleIncrease"
       @decrease="handleDecrease"
@@ -119,6 +121,8 @@ export default defineComponent({
     const popupBatteries = ref(0);
     const popupBatteryCharge = ref(0);
     const popupTotalPowerCost = ref(0);
+    const popupSolarPanelCost = ref(0);
+    const popupBatteryCost = ref(0);
 
     const generatePositions = (count: number, start: number): number[] => {
       const positions = [];
@@ -270,6 +274,8 @@ export default defineComponent({
       try {
         const data = await fetchStartLevel(levelNumber);
         console.log("Initial level data:", data);
+        popupSolarPanelCost.value = data.cost.solarPanelCost;
+        popupBatteryCost.value = data.cost.batteryCost;
         const lastHourData = data.hours[data.hours.length - 1]; // Get the data for the final hour
         transformerPositions.value = generatePositions(lastHourData.transformers.length, 20);
         housePositions.value = generatePositions(
@@ -303,6 +309,8 @@ export default defineComponent({
       popupTotalPowerCost,
       popupBatteries,
       popupBatteryCharge,
+      popupSolarPanelCost,
+      popupBatteryCost,
       showHouseDetails,
       showTransformerDetails,
       updateSolarPanels,


### PR DESCRIPTION
This pull request introduces a new `Cost` class and integrates it into the `Level` class to manage the costs associated with solar panels and batteries. The changes span across the back-end and front-end codebases to ensure the new cost data is properly handled and displayed.

### Back-end changes:

* [`back-end/src/main/java/nl/hu/serious_game/domain/Cost.java`](diffhunk://#diff-f024e44ad1d83e1a6122040cdd9d4e1f1d5f3b20422fbc8ed175bf3ee73d82c0R1-R40): Added a new `Cost` class to encapsulate the costs of solar panels and batteries.
* [`back-end/src/main/java/nl/hu/serious_game/domain/Level.java`](diffhunk://#diff-ecde84541429596d567f06f6df6adbd6da7f893194c87d16e24074a896011e6fR14-R21): Updated the `Level` class to include a `Cost` attribute and provided a getter method for it. [[1]](diffhunk://#diff-ecde84541429596d567f06f6df6adbd6da7f893194c87d16e24074a896011e6fR14-R21) [[2]](diffhunk://#diff-ecde84541429596d567f06f6df6adbd6da7f893194c87d16e24074a896011e6fR67-R70)
* [`back-end/src/main/java/nl/hu/serious_game/Runner.java`](diffhunk://#diff-3602d41de05d22d4115e748c0720e90ef709390bf99f32fa39ea97139685c9d9L38-R38): Modified the `createLevel1` and `createLevel2` methods to include the new `Cost` object when creating levels. [[1]](diffhunk://#diff-3602d41de05d22d4115e748c0720e90ef709390bf99f32fa39ea97139685c9d9L38-R38) [[2]](diffhunk://#diff-3602d41de05d22d4115e748c0720e90ef709390bf99f32fa39ea97139685c9d9L62-R62)
* [`back-end/src/main/java/nl/hu/serious_game/application/LevelService.java`](diffhunk://#diff-097c225a1fd3ec21706dd19d9b701f56ce088ce97c75a21c45f0980cbb3e088dL112-R112): Updated the `runLevel` method to include the `Cost` data in the `LevelDTO` object.

### Front-end changes:

* [`front-end/src/components/PopupComponent.vue`](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L83-R83): Updated the component to display the costs of solar panels and batteries. [[1]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L83-R83) [[2]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955L109-R109) [[3]](diffhunk://#diff-7526c0d969ef1241a86be29db843e4c8625e0f0d94a44a6c4ef9eba759c3f955R175-R182)
* [`front-end/src/pages/Level.vue`](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R57-R58): Modified the component to fetch and pass the new cost data to the `PopupComponent`. [[1]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R57-R58) [[2]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R124-R125) [[3]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R277-R278) [[4]](diffhunk://#diff-1fe0ff6752833663b60e8bb02150368d60dac41722bbe5e8edb44d2e9d246972R312-R313)

### Test updates:

* [`back-end/src/test/java/nl/hu/serious_game/LevelInitializationTest.java`](diffhunk://#diff-72457dfa5d842a1b68fe461fc7ca433a9d1f36e7db2be677f3a937acfa62609fL49-R49): Updated the test to include the `Cost` object when initializing a `Level`.
* [`back-end/src/test/java/nl/hu/serious_game/application/LevelServiceTest.java`](diffhunk://#diff-ea9ce8d1ac4a057c154581614e88e41fe3a67e35aae8c90f7e15edf35a18edb7L24-R24): Mocked the `Cost` object when creating a `Level` for testing purposes.
* [`back-end/src/test/java/nl/hu/serious_game/domain/LevelTest.java`](diffhunk://#diff-9ae4978bf97d7835f7402782921f18d869d9cf2a3600e7975345fe856ba73aa4L14-R14): Added the `Cost` object to the `Level` constructor in the test case.