### PR TITLE
Kleur op wit gezet (voorkomt automatische kleur verandering bij light-mode)

### DIFF
--- a/front-end/src/components/Dashboard.vue
+++ b/front-end/src/components/Dashboard.vue
@@ -92,6 +92,7 @@ export default defineComponent({
   text-align: center;
   align-items: center;
   font-weight: bold;
+  color: white;
 }
 
 .underline {


### PR DESCRIPTION
This pull request includes a small change to the `Dashboard.vue` file. The change modifies the CSS style for a component to set the text color to white.

* [`front-end/src/components/Dashboard.vue`](diffhunk://#diff-9a5ced3d8f75a0b75093c947129ddc45e33909739dc7f2c0896c92455ec560d7R95): Added a `color: white;` CSS rule to the component's style block.