### PR TITLE
fix error when deleting level templates

### DIFF
--- a/back-end/HTTP-requests.http
+++ b/back-end/HTTP-requests.http
@@ -1,11 +1,11 @@
 ### Get template list
 GET http://localhost:8080/templates
 
-### Get template list
-DELETE http://localhost:8080/templates/delete/5
+### Delete template 1
+DELETE http://localhost:8080/templates/1
 
 ### Create template
-POST http://localhost:8080/templates/create
+POST http://localhost:8080/templates
 Content-Type: application/json
 
 {
@@ -41,7 +41,7 @@ Content-Type: application/json
 }
 
 ### Update template
-POST http://localhost:8080/templates/update/102
+POST http://localhost:8080/templates/102
 Content-Type: application/json
 
 {
@@ -81,6 +81,15 @@ GET http://localhost:8080/levels/start/1
 
 ### Start level 2
 GET http://localhost:8080/levels/start/2
+
+### Start level 3
+GET http://localhost:8080/levels/start/3
+
+### Start level 4
+GET http://localhost:8080/levels/start/4
+
+### Start level 5
+GET http://localhost:8080/levels/start/5
 
 ### Update level 1
 POST http://localhost:8080/levels/update/1

--- a/back-end/src/main/java/nl/hu/serious_game/SeedLevelTemplateRunner.java
+++ b/back-end/src/main/java/nl/hu/serious_game/SeedLevelTemplateRunner.java
@@ -2,6 +2,9 @@ package nl.hu.serious_game;
 
 import java.util.List;
 
+import nl.hu.serious_game.presentation.GameLevelController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -19,6 +22,7 @@ import nl.hu.serious_game.domain.Season;
 
 @Component
 public class SeedLevelTemplateRunner implements CommandLineRunner {
+    private final Logger logger = LoggerFactory.getLogger(SeedLevelTemplateRunner.class);
     private final LevelTemplateRepository levelTemplateRepository;
 
     @Autowired
@@ -28,7 +32,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        System.out.println("Runner started!");
+        logger.info("Runner started!");
         if (levelTemplateRepository.getLevelCount() == 0) {
             levelTemplateRepository.save(createLevel1());
             levelTemplateRepository.save(createLevel2());
@@ -38,7 +42,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
     }
 
     public LevelTemplate createLevel1() {
-        System.out.println("Creating level 1...");
+        logger.info("Creating level 1...");
         // Create objective
         Objective objective = new Objective(1, 20);
 
@@ -54,14 +58,13 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
 
         LevelTemplate level = new LevelTemplate(1, Season.SUMMER, 10, 15, objective, List.of(transformer), new Cost(5, 10));
 
-        System.out.println("Level 1 created!");
-        System.out.println(level);
+        logger.info("Level 1 created! {}", level);
 
         return level;
     }
 
     public LevelTemplate createLevel2() {
-        System.out.println("Creating level 2...");
+        logger.info("Creating level 2...");
         // Create objective
         Objective objective = new Objective(2, 50);
 
@@ -78,14 +81,13 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
 
         LevelTemplate level = new LevelTemplate(2, Season.SUMMER, 8, 15, objective, List.of(transformer), new Cost(5, 10));
 
-        System.out.println("Level 2 created!");
-        System.out.println(level);
+        logger.info("Level 2 created! {}", level);
 
         return level;
     }
 
     public LevelTemplate createLevel3() {
-        System.out.println("Creating level 3...");
+        logger.info("Creating level 3...");
         // Create objective
         Objective objective = new Objective(4, 150);
 
@@ -103,14 +105,13 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
 
         LevelTemplate level = new LevelTemplate(3, Season.SUMMER, 11, 19, objective, List.of(transformer), new Cost(5, 10));
 
-        System.out.println("Level 3 created!");
-        System.out.println(level);
+        logger.info("Level 3 created! {}", level);
 
         return level;
     }
 
     public LevelTemplate createLevel4() {
-        System.out.println("Creating level 4...");
+        logger.info("Creating level 4...");
         // Create objective
         Objective objective = new Objective(5, 100);
 
@@ -129,8 +130,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
 
         LevelTemplate level = new LevelTemplate(4, Season.SUMMER, 10, 18, objective, List.of(transformer), new Cost(5, 10));
 
-        System.out.println("Level 4 created!");
-        System.out.println(level);
+        logger.info("Level 4 created! {}", level);
 
         return level;
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameHouse.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameHouse.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Entity
@@ -16,8 +18,14 @@ public class GameHouse implements Cloneable {
     @GeneratedValue
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LevelHouse template;
+
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @Setter // being set by GameTransformer's constructor.
+    private GameTransformer transformer;
 
     private int totalSolarPanels;
 

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nl.hu.serious_game.domain.exceptions.DoesNotExistException;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Entity
@@ -18,10 +20,11 @@ public class GameLevel implements Cloneable {
     @GeneratedValue
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LevelTemplate template;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "level")
     private List<GameTransformer> transformers = new ArrayList<>();
     private boolean isCompleted = false;
     private int totalCosts = 0; // Cost in coins
@@ -33,6 +36,10 @@ public class GameLevel implements Cloneable {
             this.transformers = transformers;
         } else {
             throw new IllegalArgumentException("transformers is empty");
+        }
+
+        for (var transformer : transformers) {
+            transformer.setLevel(this);
         }
     }
 

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import nl.hu.serious_game.domain.exceptions.DoesNotExistException;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Entity
@@ -19,10 +21,16 @@ public class GameTransformer implements Cloneable {
     @GeneratedValue
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @Setter // being set by LevelTransformer's constructor.
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private LevelTransformer template;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @Setter // being set by GameLevel's constructor.
+    private GameLevel level;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "transformer")
     private List<GameHouse> houses;
 
     @OneToOne(cascade = CascadeType.ALL)
@@ -33,6 +41,10 @@ public class GameTransformer implements Cloneable {
         this.template = template;
         this.houses = houses;
         this.battery = new Battery(batteries);
+
+        for (var house : houses) {
+            house.setTransformer(this);
+        }
     }
 
     public Current getCalculatedLeftoverCurrentAtHour(int hour) {

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
@@ -47,6 +47,17 @@ public class GameTransformer implements Cloneable {
         }
     }
 
+    public GameTransformer(long id, LevelTransformer template, List<GameHouse> houses, int batteries) {
+        this.id = id;
+        this.template = template;
+        this.houses = houses;
+        this.battery = new Battery(batteries);
+
+        for (var house : houses) {
+            house.setTransformer(this);
+        }
+    }
+
     public Current getCalculatedLeftoverCurrentAtHour(int hour) {
         float demand = 0;
         float production = 0;

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelHouse.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelHouse.java
@@ -1,8 +1,6 @@
 package nl.hu.serious_game.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +19,10 @@ public class LevelHouse {
     private DayProfile dayProfile;
     @Setter
     private HouseOptions houseOptions;
+
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @Setter // being set by LevelTransformer's constructor.
+    private LevelTransformer transformer;
 
     public LevelHouse(DayProfile dayProfile, HouseOptions houseOptions) {
         this.dayProfile = dayProfile;

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTemplate.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTemplate.java
@@ -33,7 +33,7 @@ public class LevelTemplate {
     @Setter
     private Cost cost;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "level")
     private List<LevelTransformer> transformers = new ArrayList<>();
 
     public LevelTemplate(int levelNumber, Season season, int startTime, int endTime, Objective objective, List<LevelTransformer> transformers, Cost cost) {
@@ -44,5 +44,9 @@ public class LevelTemplate {
         this.objective = objective;
         this.transformers = transformers;
         this.cost = cost;
+
+        for (var transformer : transformers) {
+            transformer.setLevel(this);
+        }
     }
 }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
@@ -20,8 +20,12 @@ public class LevelTransformer {
     @Setter
     private Congestion congestion;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "transformer")
     private List<LevelHouse> houses;
+
+    @ManyToOne(cascade = CascadeType.ALL, optional = false)
+    @Setter // being set by LevelTemplate's constructor.
+    private LevelTemplate level;
 
     @Setter
     private int maxBatteryCount = 4;
@@ -30,5 +34,9 @@ public class LevelTransformer {
         this.congestion = congestion;
         this.houses = houses;
         this.maxBatteryCount = maxBatteryCount;
+
+        for (var house : houses) {
+            house.setTransformer(this);
+        }
     }
 }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
@@ -39,4 +39,15 @@ public class LevelTransformer {
             house.setTransformer(this);
         }
     }
+
+    public LevelTransformer(long id, Congestion congestion, List<LevelHouse> houses, int maxBatteryCount) {
+        this.id = id;
+        this.congestion = congestion;
+        this.houses = houses;
+        this.maxBatteryCount = maxBatteryCount;
+
+        for (var house : houses) {
+            house.setTransformer(this);
+        }
+    }
 }

--- a/back-end/src/main/java/nl/hu/serious_game/presentation/GameLevelController.java
+++ b/back-end/src/main/java/nl/hu/serious_game/presentation/GameLevelController.java
@@ -3,6 +3,8 @@ package nl.hu.serious_game.presentation;
 import nl.hu.serious_game.application.GameLevelService;
 import nl.hu.serious_game.application.dto.in.GameLevelUpdateDTO;
 import nl.hu.serious_game.application.dto.out.GameLevelDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/levels")
 public class GameLevelController {
-
+    private final Logger logger = LoggerFactory.getLogger(GameLevelController.class);
     private final GameLevelService gameLevelService;
 
     @Autowired
@@ -22,9 +24,11 @@ public class GameLevelController {
     public ResponseEntity<GameLevelDTO> startLevel(@PathVariable int levelNumber) {
         try {
             GameLevelDTO level = gameLevelService.startGame(levelNumber);
-            System.out.println("start: levelNumber = " + levelNumber);
+            logger.debug("start: levelNumber = {}", levelNumber);
             return ResponseEntity.ok(level);
         } catch (IllegalArgumentException e) {
+            logger.error("Error starting level", e);
+
             return ResponseEntity.badRequest().build();
         }
     }
@@ -33,9 +37,10 @@ public class GameLevelController {
     public ResponseEntity<GameLevelDTO> updateLevel(@PathVariable int levelNumber, @RequestBody GameLevelUpdateDTO levelUpdateDTO) {
         try {
             GameLevelDTO updatedLevel = gameLevelService.updateGame(levelNumber, levelUpdateDTO);
-            System.out.println("update: levelNumber = " + levelNumber);
+            logger.debug("update: levelNumber = {}", levelNumber);
             return ResponseEntity.ok(updatedLevel);
         } catch (IllegalArgumentException e) {
+            logger.error("Error updating level", e);
             return ResponseEntity.badRequest().build();
         }
     }

--- a/back-end/src/test/java/nl/hu/serious_game/GameLevelInitializationTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/GameLevelInitializationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.reactive.TransactionalOperator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +47,7 @@ public class GameLevelInitializationTest {
     @Test
     @DisplayName("Test level initialization")
     public void testLevelInitialization() {
-        GameLevel level = new GameLevel(new LevelTemplate(1, season, startTime, endTime, objective, null, new Cost(5, 10)), transformers);
+        GameLevel level = new GameLevel(new LevelTemplate(1, season, startTime, endTime, objective, List.of(), new Cost(5, 10)), transformers);
 
         assertNotNull(level.getTemplate().getObjective(), "Template objective should be initialized");
         assertEquals(objective, level.getTemplate().getObjective(), "Template objective should match the provided value");

--- a/back-end/src/test/java/nl/hu/serious_game/application/GameLevelServiceTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/application/GameLevelServiceTest.java
@@ -26,10 +26,10 @@ public class GameLevelServiceTest {
         LevelTemplateRepository levelTemplateRepository = mock(LevelTemplateRepository.class);
         GameLevelRepository gameLevelRepository = mock(GameLevelRepository.class);
 
-        LevelTransformer levelTransformer = new LevelTransformer(new Congestion(), List.of(), 0);
+        LevelTransformer levelTransformer = new LevelTransformer(1L, new Congestion(), List.of(), 0);
         LevelTemplate levelTemplate = new LevelTemplate(1L, 1, Season.SUMMER, 8, 18, new Objective(2, 5), new Cost(), List.of(levelTransformer));
 
-        when(gameLevelRepository.save(Mockito.any())).thenReturn(new GameLevel(1L, levelTemplate, List.of(new GameTransformer(levelTransformer, List.of(), 0)), false, 0, 0));
+        when(gameLevelRepository.save(Mockito.any())).thenReturn(new GameLevel(1L, levelTemplate, List.of(new GameTransformer(1L, levelTransformer, List.of(), 0)), false, 0, 0));
         when(levelTemplateRepository.getLevelTemplateByLevelNumber(1)).thenReturn(Optional.of(levelTemplate));
         this.gameLevelService = new GameLevelService(gameLevelRepository, levelTemplateRepository);
     }

--- a/back-end/src/test/java/nl/hu/serious_game/application/GameLevelServiceTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/application/GameLevelServiceTest.java
@@ -26,10 +26,10 @@ public class GameLevelServiceTest {
         LevelTemplateRepository levelTemplateRepository = mock(LevelTemplateRepository.class);
         GameLevelRepository gameLevelRepository = mock(GameLevelRepository.class);
 
-        LevelTransformer levelTransformer = new LevelTransformer(1L, new Congestion(), List.of(), 0);
+        LevelTransformer levelTransformer = new LevelTransformer(new Congestion(), List.of(), 0);
         LevelTemplate levelTemplate = new LevelTemplate(1L, 1, Season.SUMMER, 8, 18, new Objective(2, 5), new Cost(), List.of(levelTransformer));
 
-        when(gameLevelRepository.save(Mockito.any())).thenReturn(new GameLevel(1L, levelTemplate, List.of(new GameTransformer(1L, levelTransformer, List.of(), new Battery(0), new Current())), false, 0, 0));
+        when(gameLevelRepository.save(Mockito.any())).thenReturn(new GameLevel(1L, levelTemplate, List.of(new GameTransformer(levelTransformer, List.of(), 0)), false, 0, 0));
         when(levelTemplateRepository.getLevelTemplateByLevelNumber(1)).thenReturn(Optional.of(levelTemplate));
         this.gameLevelService = new GameLevelService(gameLevelRepository, levelTemplateRepository);
     }

--- a/back-end/src/test/java/nl/hu/serious_game/domain/GameTransformerTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/GameTransformerTest.java
@@ -26,7 +26,7 @@ public class GameTransformerTest {
         List<GameHouse> houses = new ArrayList<>();
         houses.add(mockHouse);
 
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), null, 0), houses, 0);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), List.of(), 0), houses, 0);
         assertEquals(expected1, transformer.getCalculatedLeftoverCurrentAtHour(1));
         assertEquals(expected2, transformer.getCalculatedLeftoverCurrentAtHour(2));
     }
@@ -46,7 +46,7 @@ public class GameTransformerTest {
 
         // Adding a second battery would break the test
         // because all 6 of the first getcurrent would go into the battery.
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), null, 0), houses, 1);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), List.of(), 0), houses, 1);
 
         assertEquals(expected1, transformer.getCalculatedLeftoverCurrentAtHour(1));
         assertEquals(expected2, transformer.getCalculatedLeftoverCurrentAtHour(2));
@@ -76,7 +76,7 @@ public class GameTransformerTest {
         Current expected3 = new Current(9F, Direction.DEMAND);
         Current expected4 = new Current(9F, Direction.PRODUCTION);
 
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), null, 0), houses, 0);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), List.of(), 0), houses, 0);
 
         // Checks if production and demand get compensated for eachother.
         assertEquals(expected1, transformer.getCalculatedLeftoverCurrentAtHour(1));
@@ -102,7 +102,7 @@ public class GameTransformerTest {
         // 5 goes into the battery and 1 is left over.
         Current expected = new Current(1F, Direction.PRODUCTION);
 
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), null, 0), houses, 1);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(false, 0f), List.of(), 0), houses, 1);
 
         assertEquals(expected, transformer.getCalculatedLeftoverCurrentAtHour(1));
     }
@@ -114,7 +114,7 @@ public class GameTransformerTest {
         when(mockHouse.getCurrentAtHour(1)).thenReturn(new Current(2F, Direction.PRODUCTION));
         List<GameHouse> houses = new ArrayList<>();
         houses.add(mockHouse);
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(true, 1f), null, 0), houses, 0);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(true, 1f), List.of(), 0), houses, 0);
         Current current = transformer.getCalculatedLeftoverCurrentAtHour(1);
         Current excess = transformer.getExcessCurrent();
         assertAll(
@@ -132,7 +132,7 @@ public class GameTransformerTest {
         when(mockHouse.getCurrentAtHour(1)).thenReturn(new Current(2F, Direction.PRODUCTION));
         List<GameHouse> houses = new ArrayList<>();
         houses.add(mockHouse);
-        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(true, 10), null, 0), houses, 0);
+        GameTransformer transformer = new GameTransformer(new LevelTransformer(new Congestion(true, 10), List.of(), 0), houses, 0);
         Current current = transformer.getCalculatedLeftoverCurrentAtHour(1);
         Current excess = transformer.getExcessCurrent();
         assertAll(


### PR DESCRIPTION
Fixes #335 

fix error when deleting level templates. in the process, also fixed hibernate using join tables for many-to-one relations.

1. OneToMany sides must specify the foreign column to map against, otherwise it will use a join table. this column will then receive CASCADE DELETE.
2. ManyToOne sides with no foreign OneToMany must have @OnDelete(CASCADE).