### PR TITLE
Fix #366: kosten van co2 niet wordt geupdate

### DIFF
--- a/back-end/HTTP-requests.http
+++ b/back-end/HTTP-requests.http
@@ -41,7 +41,7 @@ Content-Type: application/json
 }
 
 ### Update template
-POST http://localhost:8080/templates/102
+POST http://localhost:8080/templates/5
 Content-Type: application/json
 
 {
@@ -73,7 +73,12 @@ Content-Type: application/json
         }
       ]
     }
-  ]
+  ],
+  "cost": {
+    "CO2Cost": 10,
+    "solarPanelCost": 111,
+    "batteryCost": 15
+  }
 }
 
 ### Start level 1

--- a/back-end/HTTP-requests.http
+++ b/back-end/HTTP-requests.http
@@ -75,7 +75,7 @@ Content-Type: application/json
     }
   ],
   "cost": {
-    "CO2Cost": 10,
+    "co2Cost": 1222.0,
     "solarPanelCost": 111,
     "batteryCost": 15
   }

--- a/back-end/src/main/java/nl/hu/serious_game/SeedLevelTemplateRunner.java
+++ b/back-end/src/main/java/nl/hu/serious_game/SeedLevelTemplateRunner.java
@@ -56,7 +56,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
         // Create a single transformer
         LevelTransformer transformer = new LevelTransformer(new Congestion(false, 0f), List.of(house1, house2), 4);
 
-        LevelTemplate level = new LevelTemplate(1, Season.SUMMER, 10, 15, objective, List.of(transformer), new Cost(5, 10));
+        LevelTemplate level = new LevelTemplate(1, Season.SUMMER, 10, 15, objective, List.of(transformer), new Cost(5, 10, 0.5f));
 
         logger.info("Level 1 created! {}", level);
 
@@ -79,7 +79,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
         // Create a single transformer
         LevelTransformer transformer = new LevelTransformer(new Congestion(false, 0f), List.of(house1, house2, house3), 4);
 
-        LevelTemplate level = new LevelTemplate(2, Season.SUMMER, 8, 15, objective, List.of(transformer), new Cost(5, 10));
+        LevelTemplate level = new LevelTemplate(2, Season.SUMMER, 8, 15, objective, List.of(transformer), new Cost(5, 10, 0.5f));
 
         logger.info("Level 2 created! {}", level);
 
@@ -103,7 +103,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
         // Create a single transformer
         LevelTransformer transformer = new LevelTransformer(new Congestion(false, 0f), List.of(house1, house2, house3, house4), 4);
 
-        LevelTemplate level = new LevelTemplate(3, Season.SUMMER, 11, 19, objective, List.of(transformer), new Cost(5, 10));
+        LevelTemplate level = new LevelTemplate(3, Season.SUMMER, 11, 19, objective, List.of(transformer), new Cost(5, 10, 0.5f));
 
         logger.info("Level 3 created! {}", level);
 
@@ -128,7 +128,7 @@ public class SeedLevelTemplateRunner implements CommandLineRunner {
         // Create a single transformer
         LevelTransformer transformer = new LevelTransformer(new Congestion(false, 0f), List.of(house1, house2, house3, house4, house5), 4);
 
-        LevelTemplate level = new LevelTemplate(4, Season.SUMMER, 10, 18, objective, List.of(transformer), new Cost(5, 10));
+        LevelTemplate level = new LevelTemplate(4, Season.SUMMER, 10, 18, objective, List.of(transformer), new Cost(5, 10, 0.5f));
 
         logger.info("Level 4 created! {}", level);
 

--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelTemplateService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelTemplateService.java
@@ -56,7 +56,7 @@ public class LevelTemplateService {
     }
 
     public LevelTemplateDTO updateLevel(long id, LevelTemplateUpdateDTO updateLevel) {
-        LevelTemplate levelTemplate = this.levelTemplateRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+        final LevelTemplate levelTemplate = this.levelTemplateRepository.findById(id).orElseThrow(EntityNotFoundException::new);
 
         levelTemplate.setStartTime(updateLevel.startTime());
         levelTemplate.setEndTime(updateLevel.endTime());
@@ -78,13 +78,14 @@ public class LevelTemplateService {
                                         updateHouse.maxBatteries()
                                 )
                         )).toList(),
+                        levelTemplate,
                         updateTransformer.maxBatteryCount()
                 )).toList()
         );
 
-        levelTemplate = this.levelTemplateRepository.save(levelTemplate);
+        var savedLevelTemplate = this.levelTemplateRepository.save(levelTemplate);
 
-        return LevelTemplateDTO.fromEntity(levelTemplate);
+        return LevelTemplateDTO.fromEntity(savedLevelTemplate);
     }
 
     public List<LevelTemplateDTO> getAllLevels() {

--- a/back-end/src/main/java/nl/hu/serious_game/application/LevelTemplateService.java
+++ b/back-end/src/main/java/nl/hu/serious_game/application/LevelTemplateService.java
@@ -83,7 +83,7 @@ public class LevelTemplateService {
                 )).toList()
         );
 
-        var savedLevelTemplate = this.levelTemplateRepository.save(levelTemplate);
+        LevelTemplate savedLevelTemplate = this.levelTemplateRepository.save(levelTemplate);
 
         return LevelTemplateDTO.fromEntity(savedLevelTemplate);
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/Cost.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/Cost.java
@@ -10,22 +10,18 @@ import lombok.Getter;
 public class Cost {
     private int solarPanelCost; // Cost in coins
     private int batteryCost; // Cost in coins
-    private float CO2Cost = 0.5f; // 1 kWh of gray current equals 0.5 kg of CO2, so 1 kWh = 0.5 kg CO2
+    private float co2Cost; // 1 kWh of gray current equals 0.5 kg of CO2, so 1 kWh = 0.5 kg CO2
 
     // Default constructor for when no specific costs are given
     public Cost() {
         this.solarPanelCost = 0;
         this.batteryCost = 0;
+        this.co2Cost = 0f;
     }
 
-    public Cost(int solarPanelCost, int batteryCost) {
+    public Cost(int solarPanelCost, int batteryCost, float co2Cost) {
         this.solarPanelCost = solarPanelCost;
         this.batteryCost = batteryCost;
-    }
-
-    public Cost(int solarPanelCost, int batteryCost, int CO2Cost) {
-        this.solarPanelCost = solarPanelCost;
-        this.batteryCost = batteryCost;
-        this.CO2Cost = CO2Cost;
+        this.co2Cost = co2Cost;
     }
 }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
@@ -92,7 +92,7 @@ public class GameLevel implements Cloneable {
                     }
 
                     if (netConsumption > 0) {
-                        totalCO2 += netConsumption * this.getTemplate().getCost().getCO2Cost();
+                        totalCO2 += netConsumption * this.getTemplate().getCost().getCo2Cost();
                     }
                 }
 

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameLevel.java
@@ -38,7 +38,7 @@ public class GameLevel implements Cloneable {
             throw new IllegalArgumentException("transformers is empty");
         }
 
-        for (var transformer : transformers) {
+        for (GameTransformer transformer : transformers) {
             transformer.setLevel(this);
         }
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/GameTransformer.java
@@ -42,7 +42,7 @@ public class GameTransformer implements Cloneable {
         this.houses = houses;
         this.battery = new Battery(batteries);
 
-        for (var house : houses) {
+        for (GameHouse house : houses) {
             house.setTransformer(this);
         }
     }
@@ -53,7 +53,7 @@ public class GameTransformer implements Cloneable {
         this.houses = houses;
         this.battery = new Battery(batteries);
 
-        for (var house : houses) {
+        for (GameHouse house : houses) {
             house.setTransformer(this);
         }
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTemplate.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTemplate.java
@@ -45,7 +45,7 @@ public class LevelTemplate {
         this.transformers = transformers;
         this.cost = cost;
 
-        for (var transformer : transformers) {
+        for (LevelTransformer transformer : transformers) {
             transformer.setLevel(this);
         }
     }

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
@@ -40,6 +40,17 @@ public class LevelTransformer {
         }
     }
 
+    public LevelTransformer(Congestion congestion, List<LevelHouse> houses, LevelTemplate levelTemplate, int maxBatteryCount) {
+        this.congestion = congestion;
+        this.houses = houses;
+        this.level = levelTemplate;
+        this.maxBatteryCount = maxBatteryCount;
+
+        for (var house : houses) {
+            house.setTransformer(this);
+        }
+    }
+
     public LevelTransformer(long id, Congestion congestion, List<LevelHouse> houses, int maxBatteryCount) {
         this.id = id;
         this.congestion = congestion;

--- a/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
+++ b/back-end/src/main/java/nl/hu/serious_game/domain/LevelTransformer.java
@@ -35,7 +35,7 @@ public class LevelTransformer {
         this.houses = houses;
         this.maxBatteryCount = maxBatteryCount;
 
-        for (var house : houses) {
+        for (LevelHouse house : houses) {
             house.setTransformer(this);
         }
     }
@@ -46,7 +46,7 @@ public class LevelTransformer {
         this.level = levelTemplate;
         this.maxBatteryCount = maxBatteryCount;
 
-        for (var house : houses) {
+        for (LevelHouse house : houses) {
             house.setTransformer(this);
         }
     }
@@ -57,7 +57,7 @@ public class LevelTransformer {
         this.houses = houses;
         this.maxBatteryCount = maxBatteryCount;
 
-        for (var house : houses) {
+        for (LevelHouse house : houses) {
             house.setTransformer(this);
         }
     }

--- a/back-end/src/test/java/nl/hu/serious_game/GameLevelInitializationTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/GameLevelInitializationTest.java
@@ -47,7 +47,7 @@ public class GameLevelInitializationTest {
     @Test
     @DisplayName("Test level initialization")
     public void testLevelInitialization() {
-        GameLevel level = new GameLevel(new LevelTemplate(1, season, startTime, endTime, objective, List.of(), new Cost(5, 10)), transformers);
+        GameLevel level = new GameLevel(new LevelTemplate(1, season, startTime, endTime, objective, List.of(), new Cost(5, 10, 0.5f)), transformers);
 
         assertNotNull(level.getTemplate().getObjective(), "Template objective should be initialized");
         assertEquals(objective, level.getTemplate().getObjective(), "Template objective should match the provided value");

--- a/back-end/src/test/java/nl/hu/serious_game/domain/GameLevelTest.java
+++ b/back-end/src/test/java/nl/hu/serious_game/domain/GameLevelTest.java
@@ -11,6 +11,6 @@ public class GameLevelTest {
     @DisplayName("Test for when transformers is empty")
     public void emptyTransformersTest() {
         Objective objective = new Objective(5, 5);
-        assertThrows(IllegalArgumentException.class, () -> new GameLevel(new LevelTemplate(1, Season.SUMMER, 0, 0, objective, new ArrayList<>(), new Cost(5, 10)), new ArrayList<>()));
+        assertThrows(IllegalArgumentException.class, () -> new GameLevel(new LevelTemplate(1, Season.SUMMER, 0, 0, objective, new ArrayList<>(), new Cost(5, 10, 0.5f)), new ArrayList<>()));
     }
 }

--- a/front-end/src/components/level-editor/LevelEditor.vue
+++ b/front-end/src/components/level-editor/LevelEditor.vue
@@ -56,7 +56,7 @@
                 </div>
                 <div class="form-costs-co2 form-row">
                     <label for="costs-co2">Kosten Co2</label>
-                    <input type="number" id="costs-co2" v-model="levelTemplate.cost.CO2Cost" min="0" />
+                    <input type="number" id="costs-co2" v-model="levelTemplate.cost.co2Cost" min="0" />
                 </div>
                 <div class="form-start-time form-row">
                     <label for="start-time">Start tijd</label>
@@ -142,7 +142,7 @@ export default defineComponent({
             cost: {
                 batteryCost: 0,
                 solarPanelCost: 0,
-                CO2Cost: 0,
+                co2Cost: 0,
             },
             startTime: 0,
             endTime: 0
@@ -203,7 +203,7 @@ export default defineComponent({
                 cost: {
                     batteryCost: startLevelData.cost.batteryCost,
                     solarPanelCost: startLevelData.cost.solarPanelCost,
-                    CO2Cost: startLevelData.cost.co2Cost,
+                    co2Cost: startLevelData.cost.co2Cost,
                 },
                 startTime: startLevelData.startTime,
                 endTime: startLevelData.endTime
@@ -272,7 +272,7 @@ export default defineComponent({
             if (levelTemplate.value.transformers[0].congestion.maxCurrent < 0) return showModal('Fout', 'Maximale stroom voor transformator mag niet negatief zijn');
             if (levelTemplate.value.cost.batteryCost < 0) return showModal('Fout', 'Kosten batterij mag niet negatief zijn');
             if (levelTemplate.value.cost.solarPanelCost < 0) return showModal('Fout', 'Kosten zonnepaneel mag niet negatief zijn');
-            if (levelTemplate.value.cost.CO2Cost < 0) return showModal('Fout', 'Kosten Co2 mag niet negatief zijn');
+            if (levelTemplate.value.cost.co2Cost < 0) return showModal('Fout', 'Kosten Co2 mag niet negatief zijn');
             if (levelTemplate.value.startTime < 0 || levelTemplate.value.startTime > 24) return showModal('Fout', 'Start tijd moet tussen 0 en 24 zijn');
             if (levelTemplate.value.endTime < 0 || levelTemplate.value.endTime > 24) return showModal('Fout', 'Eind tijd moet tussen 0 en 24 zijn');
             if (levelTemplate.value.startTime >= levelTemplate.value.endTime) return showModal('Fout', 'Start tijd moet voor eind tijd zijn');

--- a/front-end/src/types/levelTemplate/ResourceCosts.ts
+++ b/front-end/src/types/levelTemplate/ResourceCosts.ts
@@ -1,5 +1,5 @@
 export interface resourceCosts {
     batteryCost: number;
     solarPanelCost: number;
-    CO2Cost: number;
+    co2Cost: number;
 }


### PR DESCRIPTION
Fixes #366 .

The property "CO2Cost" had to be renamed to co2cost or Spring wouldn't recognize it, even if the HTTP body specified it as "CO2Cost" (or any other casing). This may have been a bug outside our code, but this change fixes it.