### PR TITLE
Fix backend url

### DIFF
--- a/front-end/src/services/HTTPRequestManager.ts
+++ b/front-end/src/services/HTTPRequestManager.ts
@@ -6,6 +6,14 @@ class HTTPRequestManager {
     }
 
     private async loadConfig() {
+        this.apiUrl = {
+            "localhost": 'http://localhost:8080',
+            "frontend.dev.jonaqhan.nl": "https://frontend.dev.jonaqhan.nl",
+            "troefgame.duckdns.org": "http://troefgame.duckdns.org:5001",
+        }[window.location.hostname] || null; // Hostname does not include port
+
+        // Doesn't work, kept for future reference
+        /*
         try {
             // Misschien klopt deze URL niet
             const response = await fetch('../../docker_profiles/config.json');
@@ -18,7 +26,7 @@ class HTTPRequestManager {
             console.error('Error loading config:', error);
 
             this.apiUrl = 'http://localhost:8080';
-        }
+        }*/
     }
 
     async doFetch(path: string, method = 'GET', body: any = undefined, hasJsonResponse = true) {


### PR DESCRIPTION
Revert to the old way of selecting the backend URL based on the frontend hostname.

We should still switch to a config object that gets switched at build time, mainly to avoid leaking dev urls and to improve portability, but we should make that a research story.