### PR TITLE
Fix ai backend image size

### DIFF
--- a/ai-back-end/Dockerfile
+++ b/ai-back-end/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /app
 # This way, a code change will not invalidate the cache until the next step.
 # Installing requirements takes a long time, and this allows it to be cached independently.
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+RUN rm -rf /app/.cache
 
 # Disables Flask's debug mode
 ENV FLASK_ENV=production

--- a/ai-back-end/requirements.txt
+++ b/ai-back-end/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.0.3
 Flask-Cors==5.0.0
 transformers==4.44.2
-torch==2.5.1
+torch==2.5.1+cpu
 gunicorn==23.0.0
 sentencepiece==0.2.0


### PR DESCRIPTION
- use torch+cpu to avoid pulling in 5 gb of gpu-related dependencies
- delete cache directory after installing dependencies

This reduces the image size from 8.5 gb to 2.2 gigabytes. 1.2 gb is from the debian image. About 1 gigabyte is from our dependencies (torch is very large). Our code is still only a few kilobytes.