### PR TITLE
Feature/new dev domain

### DIFF
--- a/back-end/src/main/java/nl/hu/serious_game/config/WebConfig.java
+++ b/back-end/src/main/java/nl/hu/serious_game/config/WebConfig.java
@@ -1,22 +1,21 @@
 package nl.hu.serious_game.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Value("${cors.allowed-origins}")
+    private String allowedCorsOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        System.out.println(allowedCorsOrigins);
+
         registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:5173",
-                        "https://troefgame.duckdns.org",
-                        "https://dev.troefgame.jonaqhan.nl",
-                        "https://frontend.dev.troefgame.jonaqhan.nl",
-                        "https://troefgamedev.duckdns.org"
-                )
+                .allowedOrigins(allowedCorsOrigins.split(";"))
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/back-end/src/main/java/nl/hu/serious_game/config/WebConfig.java
+++ b/back-end/src/main/java/nl/hu/serious_game/config/WebConfig.java
@@ -10,7 +10,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "https://troefgame.duckdns.org", "https://dev.troefgame.jonaqhan.nl", "https://frontend.dev.troefgame.jonaqhan.nl")
+                .allowedOrigins(
+                        "http://localhost:5173",
+                        "https://troefgame.duckdns.org",
+                        "https://dev.troefgame.jonaqhan.nl",
+                        "https://frontend.dev.troefgame.jonaqhan.nl",
+                        "https://troefgamedev.duckdns.org"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/back-end/src/main/resources/application.properties
+++ b/back-end/src/main/resources/application.properties
@@ -9,3 +9,5 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
 firebase.keyfile=back-end/firebase-key.json
+
+cors.allowed-origins=http://localhost:5173

--- a/front-end/src/components/global/level-editor/LevelEditor.vue
+++ b/front-end/src/components/global/level-editor/LevelEditor.vue
@@ -364,8 +364,8 @@ export default defineComponent({
                 },
                 hasHeatPump: false,
                 hasElectricVehicle: false,
-                maxBatteries: 0,
-                maxSolarPanels: 0,
+                maxBatteries: 2,
+                maxSolarPanels: 14,
             });
         };
 

--- a/front-end/src/services/HTTPRequestManager.ts
+++ b/front-end/src/services/HTTPRequestManager.ts
@@ -11,6 +11,7 @@ class HTTPRequestManager {
         this.apiUrl = {
             "localhost": 'http://localhost:8080',
             "dev.troefgame.jonaqhan.nl": "https://dev.troefgame.jonaqhan.nl/backend",
+            "troefgamedev.duckdns.org": "https://troefgamedev.duckdns.org/backend",
             "troefgame.duckdns.org": "https://troefgame.duckdns.org/backend",
         }[window.location.hostname] || null; // Hostname does not include port
 

--- a/front-end/src/services/PythonService.ts
+++ b/front-end/src/services/PythonService.ts
@@ -3,6 +3,7 @@ class PythonService{
         const aiBackendUrl = {
             "localhost": 'http://localhost:5000',
             "dev.troefgame.jonaqhan.nl": "https://dev.troefgame.jonaqhan.nl/ai-backend",
+            "troefgamedev.duckdns.org": "https://troefgamedev.duckdns.org/ai-backend",
             "troefgame.duckdns.org": "https://troefgame.duckdns.org/ai-backend",
         }[window.location.hostname] || null; // Hostname does not include port
 


### PR DESCRIPTION
I have registered a new domain for our development instance: https://troefgamedev.duckdns.org

To manage this domain in DuckDNS, log in with our TROEF google account.

On the frontend I have added this domain to the backend url mappings.

On the backend I have replaced the growing list of allowed CORS domains with a configuration property. The default will work in development. It can be changed on the server at runtime by using the environment variable: CORS_ALLOWED_ORIGINS. The value of the property is split by semicolon (;).